### PR TITLE
pass through noProject flag from bin/ts-node

### DIFF
--- a/src/bin/ts-node.ts
+++ b/src/bin/ts-node.ts
@@ -20,6 +20,7 @@ interface Argv {
   project?: string
   ignoreWarnings?: string | string[]
   disableWarnings?: boolean
+  noProject?: boolean
   _: string[]
 }
 
@@ -72,6 +73,7 @@ const service = register({
   ignoreWarnings: list(argv.ignoreWarnings),
   project: argv.project,
   disableWarnings: argv.disableWarnings,
+  noProject: argv.noProject,
   isEval: isEval
 })
 


### PR DESCRIPTION
````ts-node --noProject test.ts```` doesn't seem to work without this boolean being passed through to the register function