### PR TITLE
allow tsconfig.json to have a different module than required by ts-node

### DIFF
--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -79,15 +79,15 @@ function readConfig (options: Options, cwd: string, ts: TSish) {
     compilerOptions: {}
   }
 
-  config.compilerOptions = extend({
-    target: 'es5',
-    module: 'commonjs'
-  }, config.compilerOptions, {
+  config.compilerOptions = extend(config.compilerOptions, {
     rootDir: cwd,
     sourceMap: true,
     inlineSourceMap: false,
     inlineSources: false,
     declaration: false
+  }, {
+    target: 'es5',
+    module: 'commonjs'
   })
 
   if (typeof (<TS_1_5ish> ts).parseConfigFile === 'function') {


### PR DESCRIPTION
I'm running into an issue where I need the tsconfig.json to have compilerOptions.module defined as "system", instead of "commonjs" due to karma testing. Yet I need "module" defined as "commonjs" to run gulp tasks. It may have been a feature to be able to override the "module" node via the tsconfig.json, but I'm not seeing the use case for node modules just yet. 

If tsconfig.json is supposed to overwrite the modules definition, then I could implement a feature such as 
haveing a compilerOptions.tsNodeModule node, that can then be defined as needed. And for node commands ts-node would use this instead.

See https://github.com/UIUXEngineering/angular2-jspm-seed