### PR TITLE
Allow the `disableWarnings` option to be set by an environment variable

### DIFF
--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -115,7 +115,17 @@ interface Project {
  */
 export function register (opts?: Options) {
   const cwd = process.cwd()
-  const options = extend({ getFile, getVersion, project: cwd }, opts)
+
+  const defaultOptions = {
+    getFile,
+    getVersion,
+    project: cwd,
+    disableWarnings: process.env.TSNODE_DISABLEWARNINGS,
+    compiler: process.env.TSNODE_COMPILER,
+    noProject: process.env.TSNODE_NOPROJECT,
+    isEval: process.env.TSNODE_ISEVAL
+  }
+  const options = extend(defaultOptions, opts)
 
   const project: Project = { version: 0, files: {}, versions: {} }
 


### PR DESCRIPTION
Implementation of #56.  

With these changes you can set the environment variable `TSNODE_DISABLEWARNINGS` to a truthy value in order to have ts-node ignore the warnings.

Also, while I was in there I exposed `compiler`, `noProject`, and `isEval` in a similar way.