### PR TITLE
Update mocha example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ echo "console.log('Hello, world!')" | ts-node
 ### Mocha
 
 ```sh
-mocha test.ts --require ts-node/register src/**/*.spec.ts
+mocha --require ts-node/register <files or file-globs>...
 ```
 
 ### Tape

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ mocha --require ts-node/register <files or file-globs>...
 ### Tape
 
 ```sh
-ts-node node_modules/tape/bin/tape src/**/*.spec.ts
+ts-node node_modules/tape/bin/tape <files or file-globs>...
 ```
 
 ### Gulp

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ echo "console.log('Hello, world!')" | ts-node
 ### Mocha
 
 ```sh
-mocha --require ts-node/register <files or file-globs>...
+mocha --require ts-node/register [...args]
 ```
 
 ### Tape
 
 ```sh
-ts-node node_modules/tape/bin/tape <files or file-globs>...
+ts-node node_modules/tape/bin/tape [...args]
 ```
 
 ### Gulp


### PR DESCRIPTION
The `test.ts` and `src/**/*.spec.ts` are just file or file-globs example. The position doesn't matter.

So I suggest to keep the example a bit simplier.

By the way, how do I specify --project in this case?

Currently I have to: `cd source-test && mocha --require ts-node/register test.ts && cd ..`

Fixes #84