### PR TITLE
Add `environment` flag to use `node` map resolving

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ntypescript": "^1.201507091536.1",
     "proxyquire": "^1.7.2",
     "tslint": "^3.2.1",
-    "typescript": "^1.8.7",
+    "typescript": "^1.8.10",
     "typings": "^0.7.7"
   },
   "dependencies": {

--- a/src/ts-node.spec.ts
+++ b/src/ts-node.spec.ts
@@ -4,7 +4,7 @@ import { join, normalize } from 'path'
 import proxyquire = require('proxyquire')
 import { register, VERSION } from './ts-node'
 
-const cwd = join(__dirname, '../src')
+const cwd = join(__dirname, '../tests')
 const EXEC_PATH = join(__dirname, '../dist/bin/ts-node')
 const BIN_EXEC = `node ${EXEC_PATH} --project "${cwd}"`
 

--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -169,12 +169,13 @@ export function register (opts?: Options) {
 
   // Install source map support and read from cache.
   sourceMapSupport.install({
-    retrieveFile (fileName) {
+    environment: 'node',
+    retrieveFile (fileName: string) {
       if (project.files[fileName]) {
         return getOutput(fileName)
       }
     }
-  })
+  } as any)
 
   function incrementAndAddFile (fileName: string) {
     // Add files to the hash before compilation.


### PR DESCRIPTION
Related to #55.