### PR TITLE
Make it possible to supply a configFileName

### DIFF
--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -59,6 +59,7 @@ export const EXTENSIONS = ['.ts', '.tsx']
 export interface Options {
   compiler?: string
   noProject?: boolean
+  configFileName?: string
   project?: string
   ignoreWarnings?: Array<number | string>
   disableWarnings?: boolean

--- a/src/ts-node.ts
+++ b/src/ts-node.ts
@@ -70,8 +70,8 @@ export interface Options {
  * Load TypeScript configuration.
  */
 function readConfig (options: Options, cwd: string, ts: TSCommon) {
-  const { project, noProject } = options
-  const fileName = noProject ? undefined : ts.findConfigFile(project || cwd, ts.sys.fileExists)
+  const { project, noProject, configFileName } = options
+  const fileName = configFileName || (noProject ? undefined : ts.findConfigFile(project || cwd, ts.sys.fileExists))
 
   const result = fileName ? ts.readConfigFile(fileName, ts.sys.readFile) : {
     config: {


### PR DESCRIPTION
to make it possible to override the default tsconfig.json file that is looked up
Created this change for angular2-webpack-starter the e2e fails and needs a different tsconfig.json than the normal build-run cycle.

new configuration option: configFileName