### PR TITLE
Implement `allowJs`, change diagnostics option

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "proxyquire": "^1.7.2",
     "tslint": "^3.10.2",
     "tslint-config-standard": "^1.0.0",
-    "typescript": "^1.8.10",
+    "typescript": "1.8.7",
     "typings": "^1.0.4"
   },
   "dependencies": {


### PR DESCRIPTION
Changing the method of getting diagnostics results in a huge speed-up. The old method was implemented for some reason or another (I think it was so all diagnostics would print or something) but I think the speed-up negates that. Here's the speed test before and after with `typings-core`.

```
npm run test-spec  28.59s user 0.93s system 92% cpu 31.925 total

npm run test-spec  8.50s user 0.65s system 72% cpu 12.548 total
```

Closes https://github.com/TypeStrong/ts-node/issues/123.