### PR TITLE
Enable `--fast` CLI flag for transpile mode only

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ ts-node --compiler ntypescript --project src --ignoreWarnings 2304 hello-world.t
 * **--ignoreWarnings, -i** Set an array of TypeScript diagnostic codes to ignore (also `process.env.TS_NODE_IGNORE_WARNINGS`)
 * **--disableWarnings, -d** Ignore all TypeScript errors (also `process.env.TS_NODE_DISABLE_WARNINGS`)
 * **--compilerOptions, -o** Set compiler options using JSON (E.g. `--compilerOptions '{"target":"es6"}'`) (also `process.env.TS_NODE_COMPILER_OPTIONS`)
+* **--fast, -f** Use TypeScript's `transpileModule` mode (no type checking, but faster compilation) (also `process.env.TS_NODE_FAST`)
 
 ### Programmatic Usage
 


### PR DESCRIPTION
Related to https://github.com/TypeStrong/ts-node/issues/44.

Without `--fast` tests on `typings-core`:

```
npm run test-spec  7.98s user 0.52s system 72% cpu 11.691 total
```

With `--fast` tests on `typings-core`:

```
npm run test-spec  3.52s user 0.47s system 56% cpu 7.098 total
```