### PR TITLE
Add `typings` property to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "preferGlobal": true,
   "description": "TypeScript execution environment and REPL for node",
   "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "bin": {
     "ts-node": "dist/bin.js"
   },


### PR DESCRIPTION
Allows import of the definitions in packages which want to programatically use `ts-node`.