### PR TITLE
Fix compilerOptions environment settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,6 +101,7 @@ const DEFAULT_OPTIONS: Options = {
   cacheDirectory: process.env.TS_NODE_CACHE_DIRECTORY || join(tmpdir(), 'ts-node'),
   disableWarnings: process.env.TS_NODE_DISABLE_WARNINGS,
   compiler: process.env.TS_NODE_COMPILER,
+  compilerOptions: process.env.TS_NODE_COMPILER_OPTIONS,
   project: process.env.TS_NODE_PROJECT,
   ignoreWarnings: process.env.TS_NODE_IGNORE_WARNINGS,
   fast: process.env.TS_NODE_FAST


### PR DESCRIPTION
The documentation mentions `process.env.TS_NODE_COMPILER_OPTIONS` as a way to set compiler options through the environment, however this variable was never set in `DEFAULT_OPTIONS`.