### PR TITLE
:memo: more options that can be controlled from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ ts-node --compiler ntypescript --project src --ignoreWarnings 2304 hello-world.t
 * **--compilerOptions, -O** Set compiler options using JSON (E.g. `--compilerOptions '{"target":"es6"}'`) (also `process.env.TS_NODE_COMPILER_OPTIONS`)
 * **--fast, -F** Use TypeScript's `transpileModule` mode (no type checking, but faster compilation) (also `process.env.TS_NODE_FAST`)
 * **--lazy, -L** Lazily defer TypeScript initialization until first `.ts` file
-* **--no-cache** Skip hitting the compiled JavaScript cache
-* **--cache-directory** Configure the TypeScript cache directory
+* **--no-cache** Skip hitting the compiled JavaScript cache (also `process.env.TS_NODE_CACHE`)
+* **--cache-directory** Configure the TypeScript cache directory (also `process.env.TS_NODE_CACHE_DIRECTORY`)
 
 ### Programmatic Usage
 


### PR DESCRIPTION
From : https://github.com/TypeStrong/ts-node/blob/44c389e73ae7c5c7f1c0068355ea9dc56a93b907/src/index.ts#L96-L97

I actually needed to disable cache for alm.tools integrated test runner (https://github.com/alm-tools/alm/pull/181) otherwise I get errors like the following sometimes: 

```
Cannot write file '/Users/syedb/REPOS/alm/src/$$ts-node$$/common/utils.js' because it would be overwritten by multiple input files.
```

😄  :rose: 