### PR TITLE
handle case where '*.d.ts' files are compiled and there is no output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,12 @@ export function register (opts?: Options): () => Register {
           throw new TSError(diagnosticList)
         }
 
-        return [output.outputFiles[1].text, output.outputFiles[0].text]
+        if (output.outputFiles[1] && output.outputFiles[0]) {
+          return [output.outputFiles[1].text, output.outputFiles[0].text]
+        } else {
+          // no output, we compiled a type declaration file
+          return null
+        }
       }
 
       compile = readThrough(cachedir, options, project, function (code: string, fileName: string) {
@@ -371,6 +376,10 @@ function readThrough (
       const cachePath = join(cachedir, getCacheName(code, fileName))
       const sourceMapPath = `${cachePath}.js.map`
       const out = compile(code, fileName)
+      if (out == null) {
+        // no output, we compiled a file that only had type declarations
+        return ''
+      }
 
       project.sourceMaps[fileName] = sourceMapPath
 
@@ -396,6 +405,10 @@ function readThrough (
     }
 
     const out = compile(code, fileName)
+    if (out == null) {
+      // no output, we compiled a file that only had type declarations
+      return ''
+    }
 
     const output = updateOutput(out[0], fileName, sourceMapPath)
     const sourceMap = updateSourceMap(out[1], fileName)


### PR DESCRIPTION
This fixes sporadic cases of `TypeError: Cannot read property 'text' of undefined` we were seeing when writing declaration files for existing CoffeeScript code. We're running TypeScript 2.0.3 with ts-node 1.3.0.

We have a fairly log repo with a combination of CoffeeScript and TypeScript. Things would work fine when compiling with `tsc` and using `VSCode`. But when running mocha tests with `ts:ts-node/register` as a compiler, we would occasionally see this type error.

I was able to track the problem down to `getEmitOutput()` returning empty output for type declaration files we added for interacting with our legacy CoffeeScript files.

This fix will allow us again to `import` these type declarations instead of `require`ing the CoffeeScript modules. I tried to repro this issue as a new test in this repository but was unable to. If you have any suggestions on how to do so or would like me to make any additional changes, let me know.

Thanks!