### PR TITLE
fix jsx sourcemaps with "jsx": "preserve"

### DIFF
--- a/tests/with-jsx.tsx
+++ b/tests/with-jsx.tsx
@@ -1,0 +1,3 @@
+class Foo2 {
+  render() { return <div></div> }
+}


### PR DESCRIPTION
When `"jsx": "preserve"` TS compiler option is set, the output filename is `filename.jsx`, but currently the implementation assumes `.js`. This causes the sourcemap url comment to point to an invalid path, as well as caching the output as `.js` rather than `.jsx`.