### PR TITLE
Fix https://github.com/Microsoft/TypeScript/issues/11870: Do not failon empty file list diagnostic messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,10 @@ export interface Register {
  */
 export function register (options: Options = {}): () => Register {
   const compiler = options.compiler || 'typescript'
-  const ignoreWarnings = arrify(options.ignoreWarnings || DEFAULTS.ignoreWarnings || []).map(Number)
+  const emptyFileListWarnings = [18002, 18003]
+  const ignoreWarnings = arrify(
+    options.ignoreWarnings || DEFAULTS.ignoreWarnings || []
+  ).concat(emptyFileListWarnings).map(Number)
   const disableWarnings = !!(options.disableWarnings == null ? DEFAULTS.disableWarnings : options.disableWarnings)
   const getFile = options.getFile || DEFAULTS.getFile
   const fileExists = options.fileExists || DEFAULTS.fileExists


### PR DESCRIPTION
Originally reported in https://github.com/Microsoft/TypeScript/issues/11870.

Change https://github.com/Microsoft/TypeScript/pull/11743 added a new error for TS 2.1 if the `files` list is empty, or `include`+`exclude` result in an empty set. 
This breaks usage of ts-node. 

@blakeembrey I could not find a better solution here, so appreciate your guidance.