### PR TITLE
create script using new Script 

### DIFF
--- a/src/_bin.ts
+++ b/src/_bin.ts
@@ -6,7 +6,7 @@ import Module = require('module')
 import minimist = require('minimist')
 import chalk = require('chalk')
 import { diffLines } from 'diff'
-import { createScript } from 'vm'
+import { Script } from 'vm'
 import { register, VERSION, getFile, fileExists, TSError, parse } from './index'
 
 interface Argv {
@@ -267,7 +267,7 @@ function _eval (input: string, context: any) {
 
   for (const change of changes) {
     if (change.added) {
-      const script = createScript(change.value, EVAL_FILENAME)
+      const script = new Script(change.value, EVAL_FILENAME)
 
       result = script.runInNewContext(context)
     }


### PR DESCRIPTION
createScript is mark deprecated on node.d.ts, and no documentation in (https://nodejs.org/dist/latest-v6.x/docs/api/vm.html). 
All tests passed on Ubuntu 16.