### PR TITLE
Fixed preloading of modules

### DIFF
--- a/src/_bin.ts
+++ b/src/_bin.ts
@@ -161,9 +161,7 @@ const service = register({
 })
 
 // Require specified modules before start-up.
-for (const id of arrify(argv.require)) {
-  Module._load(id)
-}
+;(Module as any)._preloadModules(arrify(argv.require))
 
 /**
  * Eval helpers.

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -169,6 +169,15 @@ describe('ts-node', function () {
         return done()
       })
     })
+
+    it('should support require from node modules', function (done) {
+      exec(`${BIN_EXEC} -r tslint -e "console.log('success')"`, function (err, stdout) {
+        expect(err).to.not.exist
+        expect(stdout).to.equal('success\n')
+
+        return done()
+      })
+    })
   })
 
   describe('register', function () {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -171,7 +171,7 @@ describe('ts-node', function () {
     })
 
     it('should support require from node modules', function (done) {
-      exec(`${BIN_EXEC} -r tslint -e "console.log('success')"`, function (err, stdout) {
+      exec(`${BIN_EXEC} -r typescript -e "console.log('success')"`, function (err, stdout) {
         expect(err).to.not.exist
         expect(stdout).to.equal('success\n')
 


### PR DESCRIPTION
Hi!

This is a PR for #257. I've added a unit test which verifies the solution. Unfortunately the typings for node doesn't contain the definition for `_preloadModules` so i had to cast to any. Maybe the typings could be added to? I saw that you authored the [node typings](https://github.com/types/env-node). 