### PR TITLE
Use os.homedir when calculating tmpdir

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -150,7 +150,7 @@ export function register (options: Options = {}): () => Register {
   const fast = !!(options.fast == null ? DEFAULTS.fast : options.fast)
   const project = options.project || DEFAULTS.project
 
-  function getTmpDir(): string{
+  function getTmpDir(): string {
     const hash: string = crypto.createHash('sha1')
       .update(homedir(), 'utf8')
       .digest('hex')

--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,13 @@ export interface Register {
   getTypeInfo (fileName: string, position: number): TypeInfo
 }
 
+function getTmpDir (): string {
+  const hash: string = crypto.createHash('sha1')
+    .update(homedir(), 'utf8')
+    .digest('hex')
+  return join(tmpdir(), 'ts-node-' + hash)
+}
+
 /**
  * Register TypeScript compiler.
  */
@@ -149,13 +156,6 @@ export function register (options: Options = {}): () => Register {
   const shouldCache = !!(options.cache == null ? DEFAULTS.cache : options.cache)
   const fast = !!(options.fast == null ? DEFAULTS.fast : options.fast)
   const project = options.project || DEFAULTS.project
-
-  function getTmpDir(): string {
-    const hash: string = crypto.createHash('sha1')
-      .update(homedir(), 'utf8')
-      .digest('hex')
-    return join(tmpdir(), 'ts-node-' + hash)
-  }
 
   const cacheDirectory = options.cacheDirectory || DEFAULTS.cacheDirectory || getTmpDir()
   const compilerOptions = extend(DEFAULTS.compilerOptions, options.compilerOptions)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { relative, basename, extname, resolve, dirname, join } from 'path'
 import { readdirSync, writeFileSync, readFileSync, statSync } from 'fs'
-import { EOL, tmpdir } from 'os'
+import { EOL, tmpdir, homedir } from 'os'
 import sourceMapSupport = require('source-map-support')
 import extend = require('xtend')
 import mkdirp = require('mkdirp')
@@ -149,7 +149,15 @@ export function register (options: Options = {}): () => Register {
   const shouldCache = !!(options.cache == null ? DEFAULTS.cache : options.cache)
   const fast = !!(options.fast == null ? DEFAULTS.fast : options.fast)
   const project = options.project || DEFAULTS.project
-  const cacheDirectory = options.cacheDirectory || DEFAULTS.cacheDirectory || join(tmpdir(), 'ts-node')
+
+  function getTmpDir(): string{
+    const hash: string = crypto.createHash('sha1')
+      .update(homedir(), 'utf8')
+      .digest('hex')
+    return join(tmpdir(), 'ts-node-' + hash)
+  }
+
+  const cacheDirectory = options.cacheDirectory || DEFAULTS.cacheDirectory || getTmpDir()
   const compilerOptions = extend(DEFAULTS.compilerOptions, options.compilerOptions)
   const originalJsHandler = require.extensions['.js']
   let result: Register

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,7 +138,7 @@ function getTmpDir (): string {
   const hash: string = crypto.createHash('sha1')
     .update(homedir(), 'utf8')
     .digest('hex')
-  return join(tmpdir(), 'ts-node-' + hash)
+  return join(tmpdir(), `ts-node-${hash}`)
 }
 
 /**
@@ -156,7 +156,6 @@ export function register (options: Options = {}): () => Register {
   const shouldCache = !!(options.cache == null ? DEFAULTS.cache : options.cache)
   const fast = !!(options.fast == null ? DEFAULTS.fast : options.fast)
   const project = options.project || DEFAULTS.project
-
   const cacheDirectory = options.cacheDirectory || DEFAULTS.cacheDirectory || getTmpDir()
   const compilerOptions = extend(DEFAULTS.compilerOptions, options.compilerOptions)
   const originalJsHandler = require.extensions['.js']


### PR DESCRIPTION
See: [issue 225](https://github.com/TypeStrong/ts-node/issues/225)

Note that instead of basing off username as I'd said there this is based off the homedir from node os.

I also wasn't sure how best to go about testing this change, if there's any recommendations on that I would happily add tests to accompany.