### PR TITLE
Set `cache.contents` (no version) on read request

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -271,7 +271,7 @@ export function register (options: Options = {}): Register {
             return undefined
           }
 
-          setCache(getFile(fileName), fileName)
+          cache.contents[fileName] = getFile(fileName)
         }
 
         return ts.ScriptSnapshot.fromString(cache.contents[fileName])


### PR DESCRIPTION
Closes https://github.com/TypeStrong/ts-node/issues/344.