### PR TITLE
Check map file exists as well as compile JS target files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -482,7 +482,7 @@ function readThrough (
     cache.sourceMaps[fileName] = sourceMapPath
 
     // Use the cache when available.
-    if (fileExists(outputPath)) {
+    if (fileExists(outputPath) && fileExists(sourceMapPath)) {
       return getFile(outputPath)
     }
 


### PR DESCRIPTION
close #362 

The problem here is that second fs.writeFileSync can fail for some reason but the target compiled JS file would be built. In this case it will be used which leads to #362 