### PR TITLE
Default to "fast", new flag `--type-check`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ echo "console.log('Hello, world!')" | ts-node
 
 ![TypeScript REPL](https://github.com/TypeStrong/ts-node/raw/master/screenshot.png)
 
+### Programmatic
+
+You can require `ts-node` and register the loader for future requires by using `require('ts-node').register({ /* options */ })`. You can also use the shortcut files `node -r ts-node/register` or `node -r ts-node/register/type-check` depending on your preferences.
+
 ### Mocha
 
 ```sh
@@ -96,22 +100,6 @@ ts-node --compiler ntypescript --project src --ignoreWarnings 2304 hello-world.t
 * **--fast, -F** Use TypeScript's `transpileModule` mode (no type checking, but faster compilation) (also `process.env.TS_NODE_FAST`)
 * **--no-cache** Skip hitting the compiled JavaScript cache (also `process.env.TS_NODE_CACHE`)
 * **--cache-directory** Configure the TypeScript cache directory (also `process.env.TS_NODE_CACHE_DIRECTORY`)
-
-## Programmatic Usage
-
-```js
-require('ts-node').register({ /* options */ })
-
-// Or using the shortcut file.
-require('ts-node/register')
-```
-
-This will register the TypeScript compiler for "on the fly" compilation support of `.ts` and `.tsx` files during the run
-of the script. From here you can use `require` to bring in modules from TypeScript files:
-
-```js
-var someModule = require('path_to_a_typescript_file');
-```
 
 ## License
 

--- a/register.js
+++ b/register.js
@@ -1,1 +1,0 @@
-require('./').register()

--- a/register/index.js
+++ b/register/index.js
@@ -1,0 +1,1 @@
+require('../').register()

--- a/register/type-check.js
+++ b/register/type-check.js
@@ -1,0 +1,3 @@
+require('../').register({
+  typeCheck: true
+})

--- a/src/_bin.ts
+++ b/src/_bin.ts
@@ -12,7 +12,7 @@ import { register, VERSION, getFile, fileExists, TSError, parse, printError } fr
 interface Argv {
   eval?: string
   print?: string
-  fast?: boolean
+  typeCheck?: boolean
   cache?: boolean
   cacheDirectory?: string
   version?: boolean
@@ -22,26 +22,24 @@ interface Argv {
   require?: string | string[]
   ignore?: boolean | string | string[]
   ignoreWarnings?: string | string[]
-  disableWarnings?: boolean
   compilerOptions?: any
   _: string[]
 }
 
 const strings = ['eval', 'print', 'compiler', 'project', 'ignoreWarnings', 'require', 'cacheDirectory', 'ignore']
-const booleans = ['help', 'fast', 'version', 'disableWarnings', 'cache']
+const booleans = ['help', 'typeCheck', 'version', 'cache']
 
 const aliases: { [key: string]: string[] } = {
   help: ['h'],
-  fast: ['F'],
   version: ['v'],
   eval: ['e'],
   print: ['p'],
   project: ['P'],
   compiler: ['C'],
   require: ['r'],
+  typeCheck: ['type-check'],
   cacheDirectory: ['cache-directory'],
   ignoreWarnings: ['I', 'ignore-warnings'],
-  disableWarnings: ['D', 'disable-warnings'],
   compilerOptions: ['O', 'compiler-options']
 }
 
@@ -102,8 +100,7 @@ const argv = minimist<Argv>(process.argv.slice(2, stop), {
   alias: aliases,
   default: {
     cache: null,
-    fast: null,
-    disableWarnings: null
+    typeCheck: null
   }
 })
 
@@ -118,7 +115,6 @@ Options:
   -r, --require [path]           Require a node module for execution
   -C, --compiler [name]          Specify a custom TypeScript compiler
   -I, --ignoreWarnings [code]    Ignore TypeScript warnings by diagnostic code
-  -D, --disableWarnings          Ignore every TypeScript warning
   -P, --project [path]           Path to TypeScript project (or \`false\`)
   -O, --compilerOptions [opts]   JSON object to merge with compiler options
   -F, --fast                     Run TypeScript compilation in transpile mode
@@ -138,14 +134,13 @@ const isPrinted = argv.print !== undefined
 
 // Register the TypeScript compiler instance.
 const service = register({
-  fast: argv.fast,
+  typeCheck: argv.typeCheck,
   cache: argv.cache,
   cacheDirectory: argv.cacheDirectory,
   compiler: argv.compiler,
   project: argv.project,
   ignore: argv.ignore,
   ignoreWarnings: argv.ignoreWarnings,
-  disableWarnings: argv.disableWarnings,
   compilerOptions: parse(argv.compilerOptions),
   getFile: isEval ? getFileEval : getFile,
   fileExists: isEval ? fileExistsEval : fileExists

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -29,6 +29,17 @@ describe('ts-node', function () {
       })
     })
 
+    it('should register via cli', function (done) {
+      exec(`node -r ../register hello-world.ts`, {
+        cwd: testDir
+      }, function (err, stdout) {
+        expect(err).to.equal(null)
+        expect(stdout).to.equal('Hello, world!\n')
+
+        return done()
+      })
+    })
+
     it('should execute cli with absolute path', function (done) {
       exec(`${BIN_EXEC} "${join(testDir, 'hello-world')}"`, function (err, stdout) {
         expect(err).to.equal(null)
@@ -78,7 +89,7 @@ describe('ts-node', function () {
     })
 
     it('should throw errors', function (done) {
-      exec(`${BIN_EXEC} -e "import * as m from './tests/module';console.log(m.example(123))"`, function (err) {
+      exec(`${BIN_EXEC} --type-check -e "import * as m from './tests/module';console.log(m.example(123))"`, function (err) {
         expect(err.message).to.match(new RegExp(
           // Node 0.10 can not override the `lineOffset` option.
           '\\[eval\\]\\.ts \\(1,59\\): Argument of type \'(?:number|123)\' ' +
@@ -91,7 +102,7 @@ describe('ts-node', function () {
 
     it('should be able to ignore errors', function (done) {
       exec(
-        `${BIN_EXEC} --ignoreWarnings 2345 -e "import * as m from './tests/module';console.log(m.example(123))"`,
+        `${BIN_EXEC} --type-check --ignoreWarnings 2345 -e "import * as m from './tests/module';console.log(m.example(123))"`,
         function (err) {
           expect(err.message).to.match(
             /TypeError: (?:(?:undefined|foo\.toUpperCase) is not a function|.*has no method \'toUpperCase\')/
@@ -102,28 +113,8 @@ describe('ts-node', function () {
       )
     })
 
-    it('should be able to disable warnings from environment', function (done) {
-      exec(
-        `${BIN_EXEC} tests/compiler-error`,
-        {
-          env: {
-            PATH: process.env.PATH,
-            HOME: process.env.HOME,
-            TS_NODE_DISABLE_WARNINGS: true
-          }
-        },
-        function (err) {
-          expect(err.message).to.match(
-            /TypeError: (?:(?:undefined|str\.toUpperCase) is not a function|.*has no method \'toUpperCase\')/
-          )
-
-          return done()
-        }
-      )
-    })
-
     it('should work with source maps', function (done) {
-      exec(`${BIN_EXEC} tests/throw`, function (err) {
+      exec(`${BIN_EXEC} --type-check tests/throw`, function (err) {
         expect(err.message).to.contain([
           `${join(__dirname, '../tests/throw.ts')}:3`,
           '  bar () { throw new Error(\'this is a demo\') }',
@@ -136,7 +127,7 @@ describe('ts-node', function () {
     })
 
     it.skip('eval should work with source maps', function (done) {
-      exec(`${BIN_EXEC} -p "import './tests/throw'"`, function (err) {
+      exec(`${BIN_EXEC} --type-check -p "import './tests/throw'"`, function (err) {
         expect(err.message).to.contain([
           `${join(__dirname, '../tests/throw.ts')}:3`,
           '  bar () { throw new Error(\'this is a demo\') }',
@@ -147,8 +138,8 @@ describe('ts-node', function () {
       })
     })
 
-    it('should ignore all warnings', function (done) {
-      exec(`${BIN_EXEC} -D -p "x"`, function (err) {
+    it('should use transpile mode by default', function (done) {
+      exec(`${BIN_EXEC} -p "x"`, function (err) {
         expect(err.message).to.contain('ReferenceError: x is not defined')
 
         return done()


### PR DESCRIPTION
Moved `./register.js` to `./register/index.js` (backward compatible), and added `./register/type-check` as a shortcut for the old behaviour.