### PR TITLE
Migrate from typings to @types packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ coverage/
 .DS_Store
 npm-debug.log
 dist/
-typings/

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "3.3.0",
   "description": "TypeScript execution environment and REPL for node",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "ts-node": "dist/bin.js",
     "_ts-node": "dist/_bin.js"
   },
   "files": [
     "dist/",
-    "typings.js",
     "register.js",
     "LICENSE"
   ],
@@ -21,7 +21,7 @@
     "test-spec": "mocha dist/**/*.spec.js -R spec --bail",
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- \"dist/**/*.spec.js\" -R spec --bail",
     "test": "npm run build && npm run lint && npm run test-cov",
-    "prepublish": "typings install && npm run build"
+    "prepublish": "npm run build"
   },
   "engines": {
     "node": ">=4.2.0"
@@ -49,7 +49,11 @@
   },
   "homepage": "https://github.com/TypeStrong/ts-node",
   "devDependencies": {
+    "@types/chai": "^4.0.4",
+    "@types/mocha": "^2.2.42",
+    "@types/proxyquire": "^1.3.28",
     "@types/react": "^16.0.2",
+    "@types/semver": "^5.3.34",
     "chai": "^4.0.1",
     "istanbul": "^0.4.0",
     "mocha": "^3.0.0",
@@ -60,10 +64,18 @@
     "semver": "^5.1.0",
     "tslint": "^5.0.0",
     "tslint-config-standard": "^6.0.1",
-    "typescript": "^2.4.1",
-    "typings": "^2.0.0"
+    "typescript": "^2.4.1"
   },
   "dependencies": {
+    "@types/arrify": "^1.0.1",
+    "@types/chalk": "^0.4.31",
+    "@types/diff": "^3.2.1",
+    "@types/minimist": "^1.2.0",
+    "@types/mkdirp": "^0.5.0",
+    "@types/node": "^8.0.27",
+    "@types/source-map-support": "^0.4.0",
+    "@types/v8flags": "types/npm-v8flags#de224ae1cd5fd7dbb4e7158a6cc7a29e5315930d",
+    "@types/yn": "types/npm-yn#ca75f6c82940fae6a06fb41d2d37a6aa9b4ea8e9",
     "arrify": "^1.0.0",
     "chalk": "^2.0.0",
     "diff": "^3.1.0",

--- a/src/_bin.ts
+++ b/src/_bin.ts
@@ -193,7 +193,7 @@ if (isEvalScript) {
 function evalAndExit (code: string, isPrinted: boolean) {
   const module = new Module(EVAL_FILENAME)
   module.filename = EVAL_FILENAME
-  module.paths = Module._nodeModulePaths(cwd)
+  module.paths = (Module as any)._nodeModulePaths(cwd)
 
   ;(global as any).__filename = EVAL_FILENAME
   ;(global as any).__dirname = cwd
@@ -256,7 +256,7 @@ function _eval (input: string, context: any) {
  * Execute some code.
  */
 function exec (code: string, filename: string, context: any) {
-  const script = new Script(code, filename)
+  const script = new Script(code, { filename: filename })
 
   return script.runInNewContext(context)
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -90,6 +90,10 @@ describe('ts-node', function () {
 
     it('should throw errors', function (done) {
       exec(`${BIN_EXEC} --type-check -e "import * as m from './tests/module';console.log(m.example(123))"`, function (err) {
+        if (err === null) {
+          return done('Command was expected to fail, but it succeeded.')
+        }
+
         expect(err.message).to.match(new RegExp(
           // Node 0.10 can not override the `lineOffset` option.
           '\\[eval\\]\\.ts \\(1,59\\): Argument of type \'(?:number|123)\' ' +
@@ -104,6 +108,10 @@ describe('ts-node', function () {
       exec(
         `${BIN_EXEC} --type-check --ignoreWarnings 2345 -e "import * as m from './tests/module';console.log(m.example(123))"`,
         function (err) {
+          if (err === null) {
+            return done('Command was expected to fail, but it succeeded.')
+          }
+
           expect(err.message).to.match(
             /TypeError: (?:(?:undefined|foo\.toUpperCase) is not a function|.*has no method \'toUpperCase\')/
           )
@@ -115,6 +123,10 @@ describe('ts-node', function () {
 
     it('should work with source maps', function (done) {
       exec(`${BIN_EXEC} --type-check tests/throw`, function (err) {
+        if (err === null) {
+          return done('Command was expected to fail, but it succeeded.')
+        }
+
         expect(err.message).to.contain([
           `${join(__dirname, '../tests/throw.ts')}:3`,
           '  bar () { throw new Error(\'this is a demo\') }',
@@ -128,6 +140,10 @@ describe('ts-node', function () {
 
     it.skip('eval should work with source maps', function (done) {
       exec(`${BIN_EXEC} --type-check -p "import './tests/throw'"`, function (err) {
+        if (err === null) {
+          return done('Command was expected to fail, but it succeeded.')
+        }
+
         expect(err.message).to.contain([
           `${join(__dirname, '../tests/throw.ts')}:3`,
           '  bar () { throw new Error(\'this is a demo\') }',
@@ -140,6 +156,10 @@ describe('ts-node', function () {
 
     it('should use transpile mode by default', function (done) {
       exec(`${BIN_EXEC} -p "x"`, function (err) {
+        if (err === null) {
+          return done('Command was expected to fail, but it succeeded.')
+        }
+
         expect(err.message).to.contain('ReferenceError: x is not defined')
 
         return done()
@@ -253,10 +273,10 @@ describe('ts-node', function () {
       let compiled: string
 
       before(function () {
-        require.extensions['.tsx'] = (m, fileName) => {
+        require.extensions['.tsx'] = (m: any, fileName) => {
           const _compile = m._compile
 
-          m._compile = (code, fileName) => {
+          m._compile = (code: string, fileName: string) => {
             compiled = code
             return _compile.call(this, code, fileName)
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -394,14 +394,14 @@ function registerExtension (
 ) {
   const old = require.extensions[ext] || originalHandler
 
-  require.extensions[ext] = function (m, filename) {
+  require.extensions[ext] = function (m: any, filename) {
     if (shouldIgnore(filename, ignore)) {
       return old(m, filename)
     }
 
     const _compile = m._compile
 
-    m._compile = function (code, fileName) {
+    m._compile = function (code: string, fileName: string) {
       debug('module._compile', fileName)
 
       return _compile.call(this, register.compile(code, fileName), fileName)

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "compilerOptions": {
     "jsx": "react"
-  },
-  "files": [
-    "../typings/globals/node/index.d.ts"
-  ]
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,9 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "inlineSources": true,
-    "types": []
+    "types": ["node", "mocha"]
   },
   "include": [
-    "src/**/*",
-    "typings/**/*"
+    "src/**/*"
   ]
 }


### PR DESCRIPTION
Allows to import this package into another TypeScript file and get proper type definitions.