### PR TITLE
Update: pretty print script TypeScript errors

### DIFF
--- a/src/_bin.ts
+++ b/src/_bin.ts
@@ -174,7 +174,16 @@ if (isEvalScript) {
     args[0] = resolve(cwd, args[0])
     process.argv = ['node'].concat(args)
     process.execArgv.unshift(__filename)
-    Module.runMain()
+    try {
+      Module.runMain()
+    } catch (error) {
+      if (error instanceof TSError) {
+        console.error(printError(error))
+        process.exit(1)
+      }
+
+      throw error
+    }
   } else {
     // Piping of execution _only_ occurs when no other script is specified.
     if ((process.stdin as any).isTTY) {


### PR DESCRIPTION
When executing `ts-node -P src/server src/server`, pretty-print any
compilation errors. The ts-node call stack is rarely useful and too
verbose for everyday usage.

Before:

```
  /home/stephen/dev/wmf/marvin/node_modules/ts-node/src/index.ts:307
          throw new TSError(formatDiagnostics(diagnosticList, cwd, ts, lineOffset))
                ^
  TSError: ⨯ Unable to compile TypeScript
  src/server/index.ts (5,45): 'webpackDevServerPort' is declared but never used. (6133)
      at getOutput (/home/stephen/dev/wmf/marvin/node_modules/ts-node/src/index.ts:307:15)
      at /home/stephen/dev/wmf/marvin/node_modules/ts-node/src/index.ts:336:16
      at Object.compile (/home/stephen/dev/wmf/marvin/node_modules/ts-node/src/index.ts:498:11)
      at Module.m._compile (/home/stephen/dev/wmf/marvin/node_modules/ts-node/src/index.ts:392:43)
      at Module._extensions..js (module.js:584:10)
      at Object.require.extensions.(anonymous function) [as .ts] (/home/stephen/dev/wmf/marvin/node_modules/ts-node/src/index.ts:395:12)
      at Module.load (module.js:507:32)
      at tryModuleLoad (module.js:470:12)
      at Function.Module._load (module.js:462:3)
      at Function.Module.runMain (module.js:609:10)
```

After (with coloring):

```
  ⨯ Unable to compile TypeScript
  src/server/index.ts (5,45): 'webpackDevServerPort' is declared but never used. (6133)
```