### PR TITLE
forward signals correctly (was: signals: ignore them)

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -5,6 +5,7 @@ import { join } from 'path'
 import v8flags = require('v8flags')
 
 const argv = process.argv.slice(2)
+const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM', 'SIGWINCH']
 
 v8flags(function (err, v8flags) {
   if (err) {
@@ -66,9 +67,7 @@ v8flags(function (err, v8flags) {
   )
 
   // Ignore signals, and instead forward them to the child process.
-  ;['SIGINT', 'SIGTERM', 'SIGWINCH'].forEach(signal => {
-    process.on(signal, () => proc.kill(signal))
-  })
+  signals.forEach(signal => process.on(signal, () => proc.kill(signal)))
 
   // On spawned close, exit this process with the same code.
   proc.on('close', (code: number, signal: string) => {

--- a/tests/signals.ts
+++ b/tests/signals.ts
@@ -1,0 +1,12 @@
+process.on('SIGINT', () => {
+  process.stdout.write('exited')
+  setTimeout(() => {
+    process.stdout.write(' fine')
+
+    // Needed to make sure what we wrote has time
+    // to be written
+    process.nextTick(() => process.exit())
+  }, 500)
+})
+
+setInterval(() => console.log('should not be reached'), 3000)


### PR DESCRIPTION
signals are passed to the spawned child process; this means
that the main process should not react to them, and instead
wait for the spawned process to exit as a result of receiving
the forwarded signal.