### PR TITLE
Include .jsx files when allow-js is true

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -63,6 +63,21 @@ describe('ts-node', function () {
           }
         )
       })
+
+      it('should include jsx when `allow-js` true', function (done) {
+        exec(
+          [
+            BIN_EXEC,
+            '-O "{\\\"allowJs\\\":true}"',
+            '-p "import { Foo2 } from \'./tests/allow-js/with-jsx\'; Foo2.sayHi()"'
+          ].join(' '),
+          function (err, stdout) {
+            expect(err).to.equal(null)
+            expect(stdout).to.equal('hello world\n')
+            return done()
+          }
+        )
+      })
     }
 
     it('should eval code', function (done) {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -74,6 +74,7 @@ describe('ts-node', function () {
           function (err, stdout) {
             expect(err).to.equal(null)
             expect(stdout).to.equal('hello world\n')
+
             return done()
           }
         )

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,7 @@ export function register (options: Options = {}): Register {
   // Enable `allowJs` when flag is set.
   if (config.options.allowJs) {
     extensions.push('.js')
+    extensions.push('.jsx')
   }
 
   // Add all files into the file hash.
@@ -216,7 +217,8 @@ export function register (options: Options = {}): Register {
    * Get the extension for a transpiled file.
    */
   function getExtension (fileName: string) {
-    if (config.options.jsx === ts.JsxEmit.Preserve && extname(fileName) === '.tsx') {
+    const ext = extname(fileName)
+    if (config.options.jsx === ts.JsxEmit.Preserve && (ext === '.tsx' || ext === '.jsx')) {
       return '.jsx'
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,6 +218,7 @@ export function register (options: Options = {}): Register {
    */
   function getExtension (fileName: string) {
     const ext = extname(fileName)
+    
     if (config.options.jsx === ts.JsxEmit.Preserve && (ext === '.tsx' || ext === '.jsx')) {
       return '.jsx'
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -218,7 +218,7 @@ export function register (options: Options = {}): Register {
    */
   function getExtension (fileName: string) {
     const ext = extname(fileName)
-    
+
     if (config.options.jsx === ts.JsxEmit.Preserve && (ext === '.tsx' || ext === '.jsx')) {
       return '.jsx'
     }

--- a/tests/allow-js/with-jsx.jsx
+++ b/tests/allow-js/with-jsx.jsx
@@ -1,0 +1,5 @@
+export class Foo2 {
+  render () { return <div></div> }
+}
+ 
+Foo2.sayHi = () => 'hello world'

--- a/tests/allow-js/with-jsx.jsx
+++ b/tests/allow-js/with-jsx.jsx
@@ -1,5 +1,7 @@
 export class Foo2 {
-  render () { return <div></div> }
+  render () { 
+    return <div /> 
+  }
 }
  
 Foo2.sayHi = () => 'hello world'


### PR DESCRIPTION
Load `.jsx` files when `allow-js: true`

Previously these files were skipped. I had to modify the registration.
```js
require('ts-node/register');
require.extensions['.jsx'] = require.extensions['.tsx'];
```

