### PR TITLE
feat(bin): pass through harmony flag to node

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -32,7 +32,9 @@ v8flags(function (err, v8flags) {
     '--perf-basic-prof',
     '--preserve-symlinks',
     '--expose-gc',
-    '--expose-http2'
+    '--expose-http2',
+    '--harmony',
+    '--harmony-async-iteration'
   ])
 
   for (let i = 0; i < argv.length; i++) {


### PR DESCRIPTION
* allow using harmony features when running ts-node. 
* support native async-iteration. 

I'm doing work with `for await` and `[Symbol.asyncIterator]` both are supported in node>=7 with `--harmony-async-iteration`. However, currently ts-node doesn't allow enabling this via args.