### PR TITLE
Update mocha docs in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ You can require `ts-node` and register the loader for future requires by using `
 mocha --require ts-node/register "test/**/*.{ts,tsx}" [...args]
 ```
 
+If you want to start mocha in watch mode you should specify the option `--watch-extensions ts,tsx` since mocha only watches js files by default.
+```sh
+mocha --require ts-node/register --watch --watch-extensions ts,tsx "test/**/*.{ts,tsx}" [...args]
+```
+
 ### Tape
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -53,13 +53,10 @@ You can require `ts-node` and register the loader for future requires by using `
 ### Mocha
 
 ```sh
-mocha --require ts-node/register "test/**/*.{ts,tsx}" [...args]
+mocha --require ts-node/register --watch-extensions ts,tsx "test/**/*.{ts,tsx}" [...args]
 ```
 
-If you want to start mocha in watch mode you should specify the option `--watch-extensions ts,tsx` since mocha only watches js files by default.
-```sh
-mocha --require ts-node/register --watch --watch-extensions ts,tsx "test/**/*.{ts,tsx}" [...args]
-```
+**Note:** `--watch-extensions` is only used in `--watch` mode.
 
 ### Tape
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can require `ts-node` and register the loader for future requires by using `
 ### Mocha
 
 ```sh
-mocha --compilers ts:ts-node/register,tsx:ts-node/register [...args]
+mocha --require ts-node/register "test/**/*.{ts,tsx}" [...args]
 ```
 
 ### Tape


### PR DESCRIPTION
Using `mocha --compilers ts:ts-node/register,tsx:ts-node/register` is now deprecated (see notes at https://github.com/mochajs/mocha/wiki/compilers-deprecation)

The new way to start tests with mocha using ts-node would be:
`mocha --require ts-node/register "test/**/*.{ts,tsx}"`