### PR TITLE
graceful shutdown

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -56,6 +56,10 @@ v8flags(function (err, v8flags) {
     { stdio: 'inherit' }
   )
 
+  // trap SIGINT. prevents main process from finishing
+  // before the child one does
+  process.once('SIGINT', () => {});
+
   proc.on('exit', function (code: number, signal: string) {
     process.on('exit', function () {
       if (signal) {

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -56,9 +56,10 @@ v8flags(function (err, v8flags) {
     { stdio: 'inherit' }
   )
 
-  // trap SIGINT. prevents main process from finishing
-  // before the child one does
-  process.once('SIGINT', () => {});
+  process.once('SIGINT', () => {
+    // trap SIGINT to prevents main process from finishing
+    // before the child one does
+  })
 
   proc.on('exit', function (code: number, signal: string) {
     process.on('exit', function () {


### PR DESCRIPTION
Fixes https://github.com/TypeStrong/ts-node/issues/457

I noticed when hitting Ctrl-C, this block of code was never called, due to the main process being terminated: https://github.com/TypeStrong/ts-node/blob/1d630f90f31ac7cc7f82b10145819e9405d65fd3/src/bin.ts#L59-L67

By creating a trap to `SIGINT`, the main process will be closed only after the child one does.