### PR TITLE
Improve performance of mocha/ts-node on large projects

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -224,12 +224,7 @@ export function register (options: Options = {}): Register {
 
   // Add all files into the file hash.
   for (const fileName of config.fileNames) {
-    const regexpContent = ['.d.ts'].concat(extensions).map(e => e.replace(/\./g, '\\.')).join('|')
-    // going to look something like /(\.d\.ts|\.ts|\.tsx)$/
-    const regexp = new RegExp('(' + regexpContent + ')$')
-    if (regexp.test(fileName)) {
-      cache.versions[fileName] = 1
-    }
+    cache.versions[fileName] = 1
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,9 +288,9 @@ export function register (options: Options = {}): Register {
     // Create the compiler host for type checking.
     const serviceHost = {
       getScriptFileNames: () => Object.keys(cache.versions),
-      getScriptVersion: (fileName: string): any => {
+      getScriptVersion: (fileName: string) => {
         const version = cache.versions[fileName]
-        return version !== undefined ? String(version) : undefined
+        return (version !== undefined ? String(version) : undefined) as string
       },
       getScriptSnapshot (fileName: string) {
         if (!cache.contents[fileName]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,7 +296,7 @@ export function register (options: Options = {}): Register {
         // If we don't return `undefined` it results in `undefined === "undefined"` and run
         // `createProgram` again (which is very slow). Using a `string` assertion here to avoid
         // TypeScript errors from the function signature (expects `(x: string) => string`).
-        return version === undefined ? undefined as string : version
+        return version === undefined ? undefined as string : String(version)
       },
       getScriptSnapshot (fileName: string) {
         if (!cache.contents[fileName]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,8 +289,7 @@ export function register (options: Options = {}): Register {
     const serviceHost = {
       getScriptFileNames: () => Object.keys(cache.versions),
       getScriptVersion: (fileName: string): any => {
-        const version = cache.versions[fileName]
-        // tslint:disable-next-line
+        const version = cache.versions[fileName] as number | undefined
         return version !== undefined ? String(version) : undefined
       },
       getScriptSnapshot (fileName: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,7 +281,7 @@ export function register (options: Options = {}): Register {
     const setCache = function (code: string, fileName: string) {
       if (cache.contents[fileName] !== code) {
         cache.contents[fileName] = code
-        cache.versions[fileName] = ((cache.versions[fileName] || 0) + 1)
+        cache.versions[fileName] = (cache.versions[fileName] || 0) + 1
       }
     }
 
@@ -289,18 +289,12 @@ export function register (options: Options = {}): Register {
     const serviceHost = {
       getScriptFileNames: () => Object.keys(cache.versions),
       getScriptVersion: (fileName: string) => {
-        const version = cache.versions[fileName]
-        // We need to make sure we return `undefined` not as string here ("undefined"), because
-        // TypeScript internally will use `getScriptVersion` to find out the version of the files,
-        // which are not in `cache.versions`, like various `.d.ts` files in `node_modules`.
-        // Their `version` gonna be `undefined`, and if we return "undefined" as string here, TypeScript
-        // will compare `undefined === "undefined", and make a decision that the code was changed,
-        // and will run `createProgram` again. `createProgram` is very slow, and on large projects
-        // it may lead to significant degradation of bootup time.
-        //
-        // Unfortunately, TypeScript defines `getScriptVersion` signature as `(fileName: string) => string`,
-        // so to conform to it, let's cast our `undefined | string` here to `string` via `as string`.
-        return (version !== undefined ? String(version) : undefined) as string
+        // We need to return `undefined` and not a string here because TypeScript will use
+        // `getScriptVersion` and compare against their own version - which can be `undefined`.
+        // If we don't return `undefined` it results in `undefined === "undefined"` and run
+        // `createProgram` again (which is very slow). Using a `string` assertion here to avoid
+        // TypeScript errors from the function signature (expects `(x: string) => string`).
+        return cache.versions[fileName] as string
       },
       getScriptSnapshot (fileName: string) {
         if (!cache.contents[fileName]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ export interface Options {
  */
 interface Cache {
   contents: { [path: string]: string }
-  versions: { [path: string]: number }
+  versions: { [path: string]: number | undefined }
   outputs: { [path: string]: string }
 }
 
@@ -281,7 +281,7 @@ export function register (options: Options = {}): Register {
     const setCache = function (code: string, fileName: string) {
       if (cache.contents[fileName] !== code) {
         cache.contents[fileName] = code
-        cache.versions[fileName] = (cache.versions[fileName] + 1) || 1
+        cache.versions[fileName] = ((cache.versions[fileName] || 0) + 1)
       }
     }
 
@@ -289,7 +289,7 @@ export function register (options: Options = {}): Register {
     const serviceHost = {
       getScriptFileNames: () => Object.keys(cache.versions),
       getScriptVersion: (fileName: string): any => {
-        const version = cache.versions[fileName] as number | undefined
+        const version = cache.versions[fileName]
         return version !== undefined ? String(version) : undefined
       },
       getScriptSnapshot (fileName: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -290,7 +290,7 @@ export function register (options: Options = {}): Register {
       getScriptFileNames: () => Object.keys(cache.versions),
       getScriptVersion: (fileName: string) => {
         const version = cache.versions[fileName]
-        
+
         // We need to return `undefined` and not a string here because TypeScript will use
         // `getScriptVersion` and compare against their own version - which can be `undefined`.
         // If we don't return `undefined` it results in `undefined === "undefined"` and run

--- a/src/index.ts
+++ b/src/index.ts
@@ -296,7 +296,7 @@ export function register (options: Options = {}): Register {
         // If we don't return `undefined` it results in `undefined === "undefined"` and run
         // `createProgram` again (which is very slow). Using a `string` assertion here to avoid
         // TypeScript errors from the function signature (expects `(x: string) => string`).
-        return version === undefined ? undefined as string : String(version)
+        return version === undefined ? undefined as any as string : String(version)
       },
       getScriptSnapshot (fileName: string) {
         if (!cache.contents[fileName]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,12 +289,14 @@ export function register (options: Options = {}): Register {
     const serviceHost = {
       getScriptFileNames: () => Object.keys(cache.versions),
       getScriptVersion: (fileName: string) => {
+        const version = cache.versions[fileName]
+        
         // We need to return `undefined` and not a string here because TypeScript will use
         // `getScriptVersion` and compare against their own version - which can be `undefined`.
         // If we don't return `undefined` it results in `undefined === "undefined"` and run
         // `createProgram` again (which is very slow). Using a `string` assertion here to avoid
         // TypeScript errors from the function signature (expects `(x: string) => string`).
-        return cache.versions[fileName] as string
+        return version === undefined ? undefined as string : version
       },
       getScriptSnapshot (fileName: string) {
         if (!cache.contents[fileName]) {


### PR DESCRIPTION
I've recently upgraded my project from TypeScript 2.3 -> TypeScript 2.6, and ts-node from 1.2.0 to 3.3.0. After that, the mocha tests suite started to take instead of less than 1 minute, to over 15 minutes (I frankly don't know even exactly, I cancelled the task after 15 minutes). I can still run it fast without `--type-check`, but with typechecking it takes really forever.

I digged into it, and figured that it happens because on start ts-node compiles like 2-3 files per second, and my project has thousands of files, so it takes forever. The reason is - when we call `ts.getEmitOutput()`, it internally calls `synchronizeHostData()`, and inside it it checks whether the program is outdated via [isProgramUptoDate](https://github.com/Microsoft/TypeScript/blob/06dd3f246f56c763d2df0eb8bcdccdb55cca869a/src/services/services.ts#L1231), and if it returns false - it calls `createProgram`, which takes very long time.

There are 2 reasons why it thinks that the program is not up to date.

First: it thinks that [the number of files after handling each file changes](https://github.com/Microsoft/TypeScript/blob/b64944ad17450ddde30d648fce89fbb3e3599eb0/src/compiler/program.ts#L414). It happens because in `ts-node` we use [keys of `cache.versions`](https://github.com/TypeStrong/ts-node/blob/1d630f90f31ac7cc7f82b10145819e9405d65fd3/src/index.ts#L290) for the script file names, and it changes every time we handle another file.  

Second: it thinks that [some files are not up to date](https://github.com/Microsoft/TypeScript/blob/b64944ad17450ddde30d648fce89fbb3e3599eb0/src/compiler/program.ts#L419), and it happens because when it [compares versions](https://github.com/Microsoft/TypeScript/blob/b64944ad17450ddde30d648fce89fbb3e3599eb0/src/compiler/program.ts#L443), it often compares `undefined !== "undefined"`, e.g. for files like `lib.dom.ts` (note the second param is the string!). This happens because [here](https://github.com/TypeStrong/ts-node/blob/1d630f90f31ac7cc7f82b10145819e9405d65fd3/src/index.ts#L291) we may return "undefined" as a string if `fileName` is not in `cache.versions`.

So, there're 3 changes in this PR, which helped me to get type checked test run on my project to ~1 minute back.

1. Load all the files to `cache.versions` during bootup instead of just `.d.ts` files. But I'm not sure why it was chosen to initially load `.d.ts` files only.

2. Return `undefined` instead of `"undefined"` as a version if the file is not in `cache.versions`. It doesn't match the expected type signature of the `getScriptVersion` function, so I had to set `:any` as a returning type, but it really helps with the bootup performance.

3. Also, the last change, that reduced running time from 2.5 minutes to 1 minute - add a check to [`setCache`](https://github.com/TypeStrong/ts-node/blob/1d630f90f31ac7cc7f82b10145819e9405d65fd3/src/index.ts#L284), if the code is not changed - don't bump the file version.

I understand the changes are quite controversial, and would like to get your feedback on those, is possible.

Thanks!