### PR TITLE
Filter unsupported signals on Windows (#513)

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -73,7 +73,11 @@ v8flags(function (err, v8flags) {
   )
 
   // Ignore signals, and instead forward them to the child process.
-  signals.forEach(signal => process.on(signal, () => proc.kill(signal)))
+  signals.forEach(signal => process.on(signal, () => {
+    if (process.platform !== 'win32' || signal === 'SIGINT' || signal === 'SIGTERM' || signal === 'SIGKILL') {
+      proc.kill(signal)
+    }
+  }))
 
   // On spawned close, exit this process with the same code.
   proc.on('close', (code: number, signal: string) => {


### PR DESCRIPTION
This fixes issue #513.

From https://nodejs.org/api/process.html#process_signal_events:

> *Note:* Windows does not support sending signals, but Node.js offers some emulation with `process.kill()`, and `subprocess.kill()`. Sending signal 0 can be used to test for the existence of a process. Sending `SIGINT`, `SIGTERM`, and `SIGKILL` cause the unconditional termination of the target process.