### PR TITLE
Completely ignore tsconfig.json if project === false.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can set options by passing them in before the script.
 ts-node --compiler ntypescript --project src --ignoreWarnings 2304 hello-world.ts
 ```
 
-* **--project, -P** Path to load TypeScript configuration from (JSON file, a directory containing `tsconfig.json`, or `--no-project`/`false` to disable) (also `process.env.TS_NODE_PROJECT`)
+* **--project, -P** Path to load TypeScript configuration from (JSON file, a directory containing `tsconfig.json`, or `--no-project` to disable) (also `process.env.TS_NODE_PROJECT`/`process.env.TS_NODE_NO_PROJECT`)
 * **--compiler, -C** Use a custom, require-able TypeScript compiler compatible with `typescript@>=1.5.0-alpha` (also `process.env.TS_NODE_COMPILER`)
 * **--ignore** Specify an array of regular expression strings for `ts-node` to skip compiling as TypeScript (defaults to `/node_modules/`, `--no-ignore`/`false` to disable) (also `process.env.TS_NODE_IGNORE`)
 * **--ignoreWarnings, -I** Set an array of TypeScript diagnostic codes to ignore (also `process.env.TS_NODE_IGNORE_WARNINGS`)

--- a/src/_bin.ts
+++ b/src/_bin.ts
@@ -115,7 +115,7 @@ Options:
   -r, --require [path]           Require a node module for execution
   -C, --compiler [name]          Specify a custom TypeScript compiler
   -I, --ignoreWarnings [code]    Ignore TypeScript warnings by diagnostic code
-  -P, --project [path]           Path to TypeScript project (or \`false\`)
+  -P, --project [path]           Path to TypeScript project. Defaults to CWD/tsconfig.json. --no-project to skip.
   -O, --compilerOptions [opts]   JSON object to merge with compiler options
   -F, --fast                     Run TypeScript compilation in transpile mode
   --ignore [regexp], --no-ignore Set the ignore check (default: \`/node_modules/\`)

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -278,6 +278,15 @@ describe('ts-node', function () {
         return done()
       })
     })
+
+    it('should ignore tsconfig.json if --no-project is passed', function (done) {
+      exec(`node "${EXEC_PATH}" --no-project main.ts`, { cwd: join(__dirname, '../tests/no-project') }, function (err, stdout) {
+        expect(err).to.equal(null)
+        expect(stdout).to.match(/^foobar/)
+
+        return done()
+      })
+    })
   })
 
   describe('register', function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ const DEFAULTS = {
   cacheDirectory: process.env['TS_NODE_CACHE_DIRECTORY'],
   compiler: process.env['TS_NODE_COMPILER'],
   compilerOptions: parse(process.env['TS_NODE_COMPILER_OPTIONS']),
-  project: process.env['TS_NODE_PROJECT'],
+  project: process.env['TS_NODE_NO_PROJECT'] ? false : process.env['TS_NODE_PROJECT'],
   ignore: split(process.env['TS_NODE_IGNORE']),
   ignoreWarnings: split(process.env['TS_NODE_IGNORE_WARNINGS']),
   typeCheck: yn(process.env['TS_NODE_TYPE_CHECK'])
@@ -452,7 +452,14 @@ function fixConfig (config: any, ts: TSCommon) {
  * Load TypeScript configuration.
  */
 function readConfig (compilerOptions: any, project: string | boolean | undefined, cwd: string, ts: TSCommon) {
-  const result = loadSync(cwd, typeof project === 'string' ? project : undefined)
+  const result = false === project
+    ? {
+      config: {
+        files: [],
+        compilerOptions: {}
+      }
+    }
+    : loadSync(cwd, typeof project === 'string' ? project : undefined)
 
   // Override default configuration options.
   result.config.compilerOptions = Object.assign({}, result.config.compilerOptions, compilerOptions, {

--- a/tests/no-project/main.ts
+++ b/tests/no-project/main.ts
@@ -1,0 +1,1 @@
+console.log('foobar')

--- a/tests/no-project/tsconfig.json
+++ b/tests/no-project/tsconfig.json
@@ -1,0 +1,1 @@
+this is garbage which will cause ts-node to fail if it attempts to parse it.


### PR DESCRIPTION
Fixes #456
process env variables are always strings, see https://nodejs.org/api/process.html#process_process_env,
so I added TS_NODE_NO_PROJECT to set project === false
Added corresponding test.