### PR TITLE
Fix bug of TS_NODE_TYPE_CHECK and TS_NODE_CACHE not taking effect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -169,8 +169,8 @@ export function register (options: Options = {}): Register {
   ).concat(emptyFileListWarnings).map(Number)
   const getFile = options.getFile || DEFAULTS.getFile
   const fileExists = options.fileExists || DEFAULTS.fileExists
-  const shouldCache = !!(options.cache === undefined ? DEFAULTS.cache : options.cache)
-  const typeCheck = !!(options.typeCheck === undefined ? DEFAULTS.typeCheck : options.typeCheck)
+  const shouldCache = !!(!options.cache ? DEFAULTS.cache : options.cache)
+  const typeCheck = !!(!options.typeCheck ? DEFAULTS.typeCheck : options.typeCheck)
   const project = options.project === undefined ? DEFAULTS.project : options.project
   const cacheDirectory = options.cacheDirectory || DEFAULTS.cacheDirectory || getTmpDir()
   const compilerOptions = Object.assign({}, DEFAULTS.compilerOptions, options.compilerOptions)


### PR DESCRIPTION
This PR fixes the bug of the environment variables `TS_NODE_TYPE_CHECK` and `TS_NODE_CACHE` not taking effect.
This is because `cache` and `typeCheck` are set to `null` by default, so `options.cache === undefined` and `options.typeCheck === undefined` are never evaluated to true. 
I thought of setting the default values to `undefined`, but `minimist` sets undefined options to the default values of their types, which is `false`.
So, I ended up negating `option.cache` and `options.typeCheck`, though I don't know this is the best choice.