### PR TITLE
Add `--stack-trace-limit` to known flags

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -34,7 +34,8 @@ v8flags(function (err, v8flags) {
     '--preserve-symlinks',
     '--expose-gc',
     '--expose-http2',
-    '--trace-warnings'
+    '--trace-warnings',
+    '--stack-trace-limit'
   ])
 
   for (let i = 0; i < argv.length; i++) {


### PR DESCRIPTION
I use `ts-node` to run TypeScript tests and often get truncated stack traces in the output. This PR simply adds this as a recognised flag to be passed to node.

See:
* https://nodejs.org/docs/latest-v6.x/api/cli.html#cli_v8_options (LTS)