### PR TITLE
Fix #595

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -447,9 +447,10 @@ function readConfig (
 
   // Read project configuration when available.
   if (!noProject) {
-    configFileName = project ? resolve(cwd, project) : ts.findConfigFile(cwd, fileExists)
+    configFileName = project ? resolve(cwd, project) : ts.findConfigFile(normalizeSlashes(cwd), fileExists)
 
     if (configFileName) {
+      configFileName = normalizeSlashes(configFileName)
       const result = ts.readConfigFile(configFileName, readFile)
 
       if (result.error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -450,8 +450,7 @@ function readConfig (
     configFileName = project ? resolve(cwd, project) : ts.findConfigFile(normalizeSlashes(cwd), fileExists)
 
     if (configFileName) {
-      configFileName = normalizeSlashes(configFileName)
-      const result = ts.readConfigFile(configFileName, readFile)
+      const result = ts.readConfigFile(normalizeSlashes(configFileName), readFile)
 
       if (result.error) {
         throw new TSError([formatDiagnostic(result.error, cwd, ts, 0)])


### PR DESCRIPTION
The `cwd` should be normalized, see:
https://github.com/Microsoft/TypeScript/blob/16d7f4c1033cf1852a2904845b0568f932ed4f21/src/compiler/tsc.ts#L104

`normalizePath` changes eg. `C:\my\awesome\project` to `C:/my/awesome/project` on Windows.

The `test-fail-2` in #595 seems to be related to #409 though.