### PR TITLE
Resolves issue when `emitDeclarationOnly` is set in tsconfig.json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -443,6 +443,7 @@ function fixConfig (ts: TSCommon, config: any) {
   delete config.options.outFile
   delete config.options.declarationDir
   delete config.options.declarationMap
+  delete config.options.emitDeclarationOnly
 
   // Target ES5 output by default (instead of ES3).
   if (config.options.target === undefined) {


### PR DESCRIPTION
ts-node was failing when `emitDeclarationOnly` is set to `true` in tsconfig.json

Related:
#601
#602