### PR TITLE
Attempts to clarify how to use global module definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ _Environment variable denoted in parentheses._
 
 **TypeScript Node** does _not_ use `files`, `include` or `exclude`, by default. This is because a large majority projects do not use all of the files in a project directory (e.g. `Gulpfile.ts`, runtime vs tests) and parsing every file for types slows startup time. Instead, `ts-node` starts with the script file (e.g. `ts-node index.ts`) and TypeScript resolves dependencies based on imports and references.
 
-For global definitions, you can use the `typeRoots` compiler option.  This requires that your type definitions be structured as type packages (not loose TypeScript definition files).  More details on how this works can be found in the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types).
+For global definitions, you can use the `typeRoots` compiler option.  This requires that your type definitions be structured as type packages (not loose TypeScript definition files). More details on how this works can be found in the [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types).
 
 Example `tsconfig.json`:
+
 ```
 {
   "compilerOptions": {
@@ -156,20 +157,25 @@ Example `tsconfig.json`:
   }
 }
 ```
+
 Example project structure:
+
 ```
-<projcet_root>/
+<project_root>/
 -- tsconfig.json
 -- typings/
   -- <module_name>/
     -- index.d.ts
 ```
+
 Example module declaration file:
+
 ```
 declare module '<module_name>' {
     // module definitions go here
 }
 ```
+
 For module definitions, you can use [`paths`](https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping):
 
 ```json


### PR DESCRIPTION
A common point of user confusion lies around module definitions.  TypeScript compiles everything by default, so it can "discover" loose module definitions floating around the working directory.  ts-node only compiles what is necessary, so it will not discover anything automatically unless it is part of the module search path (such as `node_modules` by default).

This documentation update tries to make it a bit more clear to readers exactly what they need to do in order to get global module definitions picked up by ts-node.  Hopefully it will help reduce support requests related to global module definitions that "work fine with `tsc`" but "don't work with `ts-node`".