### PR TITLE
Add tip re. --project option in VSCode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Create a new node.js configuration, add `-r ts-node/register` to node args and m
 }
 ```
 
-> TIP: If you are using the `--project <path-to-your-tsconfig.json>` commandline argument as per the [Configuration Options](#configuration-options), and want to apply this same behavior when launching in VS Code, add an "env" key into the launch configuration:  `"env": { "TS_NODE_PROJECT": "<path-to-your-tsconfig.json>" }`
+**Note:** If you are using the `--project <tsconfig.json>` command line argument as per the [Configuration Options](#configuration-options), and want to apply this same behavior when launching in VS Code, add an "env" key into the launch configuration: `"env": { "TS_NODE_PROJECT": "<tsconfig.json>" }`.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Create a new node.js configuration, add `-r ts-node/register` to node args and m
 }
 ```
 
+> TIP: If you are using the `--project <path-to-your-tsconfig.json>` commandline argument as per the [Configuration Options](#configuration-options), and want to apply this same behavior when launching in VS Code, add an "env" key into the launch configuration:  `"env": { "TS_NODE_PROJECT": "<path-to-your-tsconfig.json>" }`
+
 ## How It Works
 
 **TypeScript Node** works by registering the TypeScript compiler for `.tsx?` and `.jsx?` (when `allowJs == true`) extensions. When node.js has an extension registered (via `require.extensions`), it will use the extension internally for module resolution. When an extension is unknown to node.js, it handles the file as `.js` (JavaScript). By default, **TypeScript Node** avoids compiling files in `/node_modules/` for three reasons:


### PR DESCRIPTION
Add a tip in the README to recommend how developers can pipe the `--project` commandline option into a VSCode config.

Inspired by trying and failing to find this info, and ultimately opening a bug about it, which contained the workaround.  https://github.com/TypeStrong/ts-node/issues/734#issuecomment-441302060