### PR TITLE
feat: command history

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -276,13 +276,13 @@ function startRepl () {
 /**
  * Eval code from the REPL.
  */
-function replEval (code: string, _context: any, _filename: string, callback: (err?: Error, result?: any) => any) {
+function replEval (code: string, _context: any, _filename: string, callback: (err: Error | null, result?: any) => any) {
   let err: Error | undefined
   let result: any
 
   // TODO: Figure out how to handle completion here.
   if (code === '.scope') {
-    callback()
+    callback(null)
     return
   }
 
@@ -295,14 +295,13 @@ function replEval (code: string, _context: any, _filename: string, callback: (er
         err = new Recoverable(error)
       } else {
         console.error(error.diagnosticText)
-        err = undefined
       }
     } else {
       err = error
     }
   }
 
-  callback(err, result)
+  callback(err || null, result)
 }
 
 /**

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -10,6 +10,7 @@ import { diffLines } from 'diff'
 import { Script } from 'vm'
 import { readFileSync, statSync } from 'fs'
 import { register, VERSION, DEFAULTS, TSError, parse } from './index'
+import { useHistory } from './history'
 
 interface Argv {
   // Node.js-like options.
@@ -240,6 +241,9 @@ function startRepl () {
     eval: replEval,
     useGlobal: true
   })
+
+  // Initialize the command history.
+  useHistory(repl)
 
   // Bookmark the point where we should reset the REPL state.
   const resetEval = appendEval('')

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,20 @@
+import { join } from 'path'
+import * as os from 'os'
+import * as fs from 'fs'
+
+// TODO: Use `repl: REPLServer` when history-related properties are added to @types/node
+export function useHistory (repl: any) {
+  repl.historySize = process.env.TS_NODE_HISTORY !== ''
+    ? Number(process.env.TS_NODE_HISTORY_SIZE || 1000)
+    : 0
+
+  if (repl.historySize > 0) {
+    const file = process.env.TS_NODE_HISTORY || join(os.homedir(), '.ts_node_history')
+    if (fs.existsSync(file)) {
+      repl.history = fs.readFileSync(file, 'utf8').split(os.EOL)
+    }
+    repl.on('exit', () => {
+      fs.writeFileSync(file, repl.history.join(os.EOL))
+    })
+  }
+}


### PR DESCRIPTION
Try upgrading to the latest Node 11 if you experience any issues. Looks like they had to revert a buggy feature in 11.4.0 (https://github.com/nodejs/node/pull/24804).

Nothing crazy going on here. Just basic history support! 😄 

- The file path defaults to `~/.ts_node_history`
- The size limit defaults to 1000
- `$TS_NODE_HISTORY` can be used to customize the file path
- `$TS_NODE_HISTORY_SIZE` can be used to limit the number of saved lines
- When `$TS_NODE_HISTORY` is an empty string, history is disabled
- When `$TS_NODE_HISTORY_SIZE` is zero, history is disabled

Closes #259 