### PR TITLE
Resolves performance issue by removing invalid config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -481,8 +481,8 @@ function readConfig (
 
   // Remove resolution of "files".
   if (!includeFiles) {
-    config.files = []
-    config.includes = []
+    delete config.files
+    delete config.includes
   }
 
   // Override default configuration options `ts-node` requires.


### PR DESCRIPTION
Setting `files` and `includes` to empty arrays creates an invalid `tsconfig.json` file - and seems to subsequently cause performance issues.

This PR will remove the properties altogether.

Fixes #754.