### PR TITLE
Update README.md to include example of using triple-slash directive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,7 @@ For module definitions, you can use [`paths`](https://www.typescriptlang.org/doc
 }
 ```
 
-Lastly, an alternative approach for custom definitions of untyped 3rd-party libraries
-is [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).
-This may be helpful if you prefer not to change your TypeScript `compilerOptions` or
-not to structure your custom type definitions like modules as is required when using
-`typeRoots`. Below is an example of using a triple-slash directive to point to a
-relative path within your project TypeScript sources:
+An alternative approach for definitions of third-party libraries are [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html). This may be helpful if you prefer not to change your TypeScript `compilerOptions` or structure your custom type definitions when using `typeRoots`. Below is an example of the triple-slash directive as a relative path within your project:
 
 ```typescript
 /// <reference types="./types/untyped_js_lib" />

--- a/README.md
+++ b/README.md
@@ -186,35 +186,17 @@ For module definitions, you can use [`paths`](https://www.typescriptlang.org/doc
 }
 ```
 
-For custom definitions of untyped 3rd-party libraries, consider adding a [triple-slash directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)
-prior the `import` of the module which requires the types. This may be especially helpful when you
-don't manage types said 3rd party libraries like modules (as seen in the above examples) and instead just include
-them in your TypeScript source directories. For example, if your directory structure looked like:
-
-```
-<project_root>/
--- tsconfig.json
--- src/
-  -- index.ts
-  -- types/
-    -- untyped_js_lib.d.ts
-```
-
-Inside of `types/untyped_js_lib.d.ts` you might find the following, or something more complex.
-
-```typescript
-declare module "untyped_js_lib";
-```
-
-Lastly, you could then write the triple-slash directive like the code below inside of `index.ts`.
+Lastly, an alternative approach for custom definitions of untyped 3rd-party libraries
+is [triple-slash directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html).
+This may be helpful if you prefer not to change your TypeScript `compilerOptions` or
+not to structure your custom type definitions like modules as is required when using
+`typeRoots`. Below is an example of using a triple-slash directive to point to a
+relative path within your project TypeScript sources:
 
 ```typescript
 /// <reference types="./types/untyped_js_lib" />
 import UntypedJsLib from "untyped_js_lib"
 ```
-
-Though this is not required for `tsc` to function, without the directive, `ts-node` is unable to
-leverage the hand-written type definitions you have created for your project.
 
 **Tip:** If you _must_ use `files`, enable `--files` flags or set `TS_NODE_FILES=true`.
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,36 @@ For module definitions, you can use [`paths`](https://www.typescriptlang.org/doc
 }
 ```
 
+For custom definitions of untyped 3rd-party libraries, consider adding a [triple-slash directive](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html)
+prior the `import` of the module which requires the types. This may be especially helpful when you
+don't manage types said 3rd party libraries like modules (as seen in the above examples) and instead just include
+them in your TypeScript source directories. For example, if your directory structure looked like:
+
+```
+<project_root>/
+-- tsconfig.json
+-- src/
+  -- index.ts
+  -- types/
+    -- untyped_js_lib.d.ts
+```
+
+Inside of `types/untyped_js_lib.d.ts` you might find the following, or something more complex.
+
+```typescript
+declare module "untyped_js_lib";
+```
+
+Lastly, you could then write the triple-slash directive like the code below inside of `index.ts`.
+
+```typescript
+/// <reference types="./types/untyped_js_lib" />
+import UntypedJsLib from "untyped_js_lib"
+```
+
+Though this is not required for `tsc` to function, without the directive, `ts-node` is unable to
+leverage the hand-written type definitions you have created for your project.
+
 **Tip:** If you _must_ use `files`, enable `--files` flags or set `TS_NODE_FILES=true`.
 
 ## Watching and Restarting


### PR DESCRIPTION
These directives are used to instruct the compiler of various types of dependencies between files that are not otherwise obvious. By leveraging them in our code, we can manage type definitions for untyped third-party JS libraries without making our project configurations more complex.

I struggled for a solid day to first understand that it was `ts-node` that was unable to locate my module type definitions and then to configure my project so that it could find them when needed. Hopefully this example might save others some time!