### PR TITLE
Cache file system operations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,9 @@ export interface Options {
  * Track the project information.
  */
 class MemoryCache {
-  fileContents    = new Map<string, string>()
-  fileVersions    = new Map<string, number>()
-  fileChecks      = new Map<string, boolean>()
+  fileContents = new Map<string, string>()
+  fileVersions = new Map<string, number>()
+  fileChecks = new Map<string, boolean>()
   directoryChecks = new Map<string, boolean>()
 
   constructor (public rootFileNames: string[] = []) {
@@ -173,14 +173,14 @@ export interface Register {
   getTypeInfo (code: string, fileName: string, position: number): TypeInfo
 }
 
-function cached(store: Map<string, boolean>, fun: (arg: string) => boolean): (arg: string) => boolean {
+function cached (store: Map<string, boolean>, fun: (arg: string) => boolean): (arg: string) => boolean {
   return (arg: string) => {
     if (!store.has(arg)) {
       store.set(arg, fun(arg))
     }
 
     return store.get(arg) || false
-  };
+  }
 }
 
 /**


### PR DESCRIPTION
Hello!

I'm using ts-node within docker with sources and node_modules mounted as volumes. I noticed that it's a bit slower than running it directly on host. That's on linux but on mac it's drastically worse so I investigated the issue a little bit more. 

First thing to do was to enable debug mode via `TS_NODE_DEBUG` env variable. It showed multiple `fileExists` and `directoryExists` operations. Those operations are more costly when using in docker mounted volumes. And much more costly when using it on mac. But when I sorted the output I was able to see that many of those operations are repeated several times for the same file/directories, for example:

```
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableIndex.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableIndex.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableIndex.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableIndex.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableIndex.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableIndex.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableIndex.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableIndex.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/Table.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/Table.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/Table.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/Table.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/Table.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/Table.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/Table.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/Table.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableUnique.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableUnique.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableUnique.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableUnique.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableUnique.ts
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableUnique.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableUnique.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/schema-builder/table/TableUnique.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/Broadcaster.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/Broadcaster.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/BroadcasterResult.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/BroadcasterResult.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/BroadcasterResult.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/Broadcaster.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/Broadcaster.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/Broadcaster.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/Broadcaster.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/EntitySubscriberInterface.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/InsertEvent.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/InsertEvent.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/InsertEvent.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/InsertEvent.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/InsertEvent.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/InsertEvent.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/RemoveEvent.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/RemoveEvent.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/RemoveEvent.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/RemoveEvent.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/RemoveEvent.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/RemoveEvent.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/UpdateEvent.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/UpdateEvent.d.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/UpdateEvent.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/UpdateEvent.ts
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/UpdateEvent.tsx
ts-node fileExists /home/node/app/node_modules/typeorm/subscriber/event/UpdateEvent.tsx
```

So I started to play with it a little bit. I thought I could cache the results of those functions and I wrote a simple `cached` function to do it. Here are benchmarks for my project (on linux):

1. without caching (plain ts-node 8.0.3):
      ```
      docker-compose down
      time docker-compose up app > /dev/null
      docker-compose up app > /dev/null
      2,30s user 0,39s system 20% cpu 13,091 total
      ```
2. with caching:
      ```
      docker-compose down
      time docker-compose up app > /dev/null
      docker-compose up app > /dev/null
      1,22s user 0,24s system 11% cpu 12,207 total
      ```

I run it multiple times. `docker-compose down` is needed to actually remove existing containers in order to get rid of any temporary files. As you can see both total time and time spent in system calls was decreased. When using on mac it can save you literally minutes and don't force you to use solutions like `docker-sync`.