### PR TITLE
Stop keeping REPL state after successful commands

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -292,6 +292,7 @@ function replEval (code: string, _context: any, _filename: string, callback: (er
 
   try {
     result = _eval(code)
+    EVAL_INSTANCE.input = ''
   } catch (error) {
     if (error instanceof TSError) {
       // Support recoverable compilations using >= node 6.


### PR DESCRIPTION
Right now, the REPL keeps the input between successful commands, leading
to some unexpected behaviours like the following:

```
~/src  ts-node
> 5
5
> +3
8
> -2
1
```

Instead of treating each line as a separate unary numeric expression,
ts-node treats the first one correctly, but then groups the 1st and
second to get "5 +3" = 8, and then the 2nd and 3rd to get "+3 -2" = 1.

This commit force-resets the input state after a successful command to
prevent this from happening.

I couldn't manage to reproduce this in tests since AFAICT it only
happens when using the REPL with a TTY, and I couldn't get this
environment to work in tests. Very open to trying again if there are
alternatives I missed.