### PR TITLE
Fix for --ignore

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -186,8 +186,10 @@ export function register (opts: Options = {}): Register {
   ].map(Number)
 
   const ignore = options.skipIgnore ? [] : (
-    options.ignore || ['/node_modules/']
-  ).map(str => new RegExp(str))
+    Array.isArray(options.ignore) ? options.ignore :
+    options.ignore ? [options.ignore] :
+    ['/node_modules/']
+  ).map(str => new RegExp(str));
 
   // Require the TypeScript compiler and configuration.
   const cwd = process.cwd()


### PR DESCRIPTION
Hello,

When running ts-node with `--ignore '/node_modules/(?!lodash-es/.*)'`, I got this error:

```
[1] TypeError: (options.ignore || ["/node_modules/"]).map is not a function
[1]     at register (/Users/tomesterez/projects/pbv4/node_modules/ts-node/dist/index.js:140:83)
[1]     at Object.init (/Users/tomesterez/projects/pbv4/node_modules/ts-node-dev/lib/compiler.js:106:7)
[1]     at module.exports (/Users/tomesterez/projects/pbv4/node_modules/ts-node-dev/lib/index.js:9:12)
[1]     at Object.<anonymous> (/Users/tomesterez/projects/pbv4/node_modules/ts-node-dev/bin/ts-node-dev:60:1)
[1]     at Module._compile (module.js:653:30)
[1]     at Object.Module._extensions..js (module.js:664:10)
[1]     at Module.load (module.js:566:32)
[1]     at tryModuleLoad (module.js:506:12)
[1]     at Function.Module._load (module.js:498:3)
[1]     at Function.Module.runMain (module.js:694:10)
```

When adding multiple `--ignore`, `options.ignore` is in fact an array but in my case it was a `string`. Here is a fix that worked for me.

Note that I'm using `ts-node-dev` so maybe the issue is related...