### PR TITLE
Add disableExit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ _Environment variable denoted in parentheses._
 * `--pretty` Use pretty diagnostic formatter (`TS_NODE_PRETTY`, default: `false`)
 * `--skip-project` Skip project config resolution and loading (`TS_NODE_SKIP_PROJECT`, default: `false`)
 * `--skip-ignore` Skip ignore checks (`TS_NODE_SKIP_IGNORE`, default: `false`)
+* `--log-error` Logs errors of types instead of exit the process (`TS_NODE_LOG_ERROR`, default: `false`)
 
 ### Programmatic Only Options
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -32,6 +32,7 @@ const args = arg({
   '--pretty': Boolean,
   '--skip-project': Boolean,
   '--skip-ignore': Boolean,
+  '--log-error': Boolean,
 
   // Aliases.
   '-e': '--eval',
@@ -62,7 +63,8 @@ const {
   '--type-check': typeCheck = DEFAULTS.typeCheck,
   '--pretty': pretty = DEFAULTS.pretty,
   '--skip-project': skipProject = DEFAULTS.skipProject,
-  '--skip-ignore': skipIgnore = DEFAULTS.skipIgnore
+  '--skip-ignore': skipIgnore = DEFAULTS.skipIgnore,
+  '--log-error': logError = DEFAULTS.logError
 } = args
 
 if (help) {
@@ -113,6 +115,7 @@ const service = register({
   ignore,
   project,
   skipIgnore,
+  logError,
   skipProject,
   compiler,
   ignoreDiagnostics,


### PR DESCRIPTION
Ts-node is a development tool, and during development sometimes you need to quickly change the code and check the result. Of course, in the final form the code types should be corrected and this can be controlled by pre-commit hook like `tsc --noEmit`, for example.

Thus, it happens that in the development process, you have to place `// @ts-ignore`, before every error, which is inconvenient. Given that TSC transpile the code even if it presence types errors, I would like to have the same opportunity in the ts-node too.

This pull request shows the `--disableExit` option (and `TS_NODE_DISABLE_EXIT` environment variable), which allows you not to stop the process when typing errors occur, but only to output these errors to the console and continue execution.

It looks like this:
<img width="479" alt="ts-node-disbleexit" src="https://user-images.githubusercontent.com/1322855/55675178-52a82c00-58c7-11e9-88ef-d473d3862cd7.png">
