### PR TITLE
Change node_modules file ignore to only affect node_modules subdirectories of cwd

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -204,12 +204,13 @@ export function register (opts: Options = {}): Register {
     ...(options.ignoreDiagnostics || [])
   ].map(Number)
 
+  const cwd = process.cwd()
+
   const ignore = options.skipIgnore ? [] : (
-    options.ignore || ['/node_modules/']
+    options.ignore || [cwd + '.*/node_modules/']
   ).map(str => new RegExp(str))
 
   // Require the TypeScript compiler and configuration.
-  const cwd = process.cwd()
   const typeCheck = options.typeCheck === true || options.transpileOnly !== true
   const compiler = require.resolve(options.compiler || 'typescript', { paths: [cwd, __dirname] })
   const ts: typeof _ts = require(compiler)


### PR DESCRIPTION
This is kind of silly, but due to https://github.com/Microsoft/vscode/issues/25312, (can't get TS types from `npm link`'d module), I've moved my local module to the `node_modules` directory of the project I'm working on. However, this causes my `ts-node` `gulpfile.ts` to not work, due to the `node_modules` ignoring.

It's an easy fix, all that needs to be changed is that the files ignored with the `/node_modules/` thing should only be ignored if they're in a `/node_modules/` *subdirectory*. My solution is to just include the cwd in the beginning of the ignore regex.

I can understand if you don't want to merge this considering how silly my reason for this change is, and the fact that there are the `skipIgnore` and `ignore` options. (Altho, do I have control over those when using `ts-node/register` w/ a `gulpfile.ts`? TBH I don't even understand how that magic works 😅)