### PR TITLE
Provide TS_NODE=true when running with ts-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ echo "console.log('Hello, world!')" | ts-node
 
 ![TypeScript REPL](https://github.com/TypeStrong/ts-node/raw/master/screenshot.png)
 
+> An environment variable `TS_NODE=true` is provided for conveniance when running with `ts-node` or registering it.
+
 ### Programmatic
 
 You can require `ts-node` and register the loader for future requires by using `require('ts-node').register({ /* options */ })`. You can also use file shortcuts - `node -r ts-node/register` or `node -r ts-node/register/transpile-only` - depending on your preferences.

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -32,6 +32,26 @@ describe('ts-node', function () {
       })
     })
 
+    it('should provide TS_NODE environment variable', function (done) {
+      exec(`${BIN_EXEC} tests/env`, function (err, stdout) {
+        expect(err).to.equal(null)
+        expect(stdout).to.equal('true\n')
+
+        return done()
+      })
+    })
+
+    it('should provide TS_NODE environment variable on register', function (done) {
+      exec(`node -r ../register env.ts`, {
+        cwd: TEST_DIR
+      }, function (err, stdout) {
+        expect(err).to.equal(null)
+        expect(stdout).to.equal('true\n')
+
+        return done()
+      })
+    })
+
     it('should register via cli', function (done) {
       exec(`node -r ../register hello-world.ts`, {
         cwd: TEST_DIR

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,11 @@ import * as _ts from 'typescript'
 export const INSPECT_CUSTOM = util.inspect.custom || 'inspect'
 
 /**
+ * Inject environment variable to check wether ts-node is used
+ */
+process.env.TS_NODE = 'true'
+
+/**
  * Debugging `ts-node`.
  */
 const shouldDebug = yn(process.env.TS_NODE_DEBUG)

--- a/tests/env.ts
+++ b/tests/env.ts
@@ -1,0 +1,1 @@
+console.log(process.env['TS_NODE'])


### PR DESCRIPTION
Provides a way to know if a program is executed via `ts-node` or not.
This allow a program to select paths to `src` or `dist` depending on the executing environment (compiled or not)

It should fix #846 