### PR TITLE
change value to pass as an argument (for --prefer-ts-exts)

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -289,7 +289,7 @@ describe('ts-node', function () {
     })
 
     it('should import ts before js when TS_NODE_PREFER_TS_EXTS env is present', function (done) {
-      exec(`${BIN_EXEC} tests/import-order/compiled`, { env: { TS_NODE_PREFER_TS_EXTS: 'true' } }, function (err, stdout) {
+      exec(`${BIN_EXEC} tests/import-order/compiled`, { env: { ...process.env, TS_NODE_PREFER_TS_EXTS: 'true' } }, function (err, stdout) {
         expect(err).to.equal(null)
         expect(stdout).to.equal('Hello, TypeScript!\n')
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -288,6 +288,15 @@ describe('ts-node', function () {
       })
     })
 
+    it('should import ts before js when TS_NODE_PREFER_TS_EXTS env is present', function (done) {
+      exec(`${BIN_EXEC} tests/import-order/compiled`, { env: { TS_NODE_PREFER_TS_EXTS: 'true' } }, function (err, stdout) {
+        expect(err).to.equal(null)
+        expect(stdout).to.equal('Hello, TypeScript!\n')
+
+        return done()
+      })
+    })
+
     it('should ignore .d.ts files', function (done) {
       exec(`${BIN_EXEC} tests/import-order/importer`, function (err, stdout) {
         expect(err).to.equal(null)

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,7 +401,7 @@ export function register (opts: Options = {}): Register {
   const register: Register = { cwd, compile, getTypeInfo, extensions, ts }
 
   // Register the extensions.
-  registerExtensions(options, extensions, ignore, register, originalJsHandler)
+  registerExtensions(options.preferTsExts, extensions, ignore, register, originalJsHandler)
 
   return register
 }
@@ -430,7 +430,7 @@ function reorderRequireExtension (ext: string) {
  * Register the extensions to support when importing files.
  */
 function registerExtensions (
-  opts: Options,
+  preferTsExts: boolean | null | undefined,
   extensions: string[],
   ignore: RegExp[],
   register: Register,
@@ -441,7 +441,7 @@ function registerExtensions (
     registerExtension(ext, ignore, register, originalJsHandler)
   }
 
-  if (opts.preferTsExts) {
+  if (preferTsExts) {
     // tslint:disable-next-line
     const preferredExtensions = new Set([...extensions, ...Object.keys(require.extensions)])
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -401,7 +401,7 @@ export function register (opts: Options = {}): Register {
   const register: Register = { cwd, compile, getTypeInfo, extensions, ts }
 
   // Register the extensions.
-  registerExtensions(opts, extensions, ignore, register, originalJsHandler)
+  registerExtensions(options, extensions, ignore, register, originalJsHandler)
 
   return register
 }


### PR DESCRIPTION
The `--prefer-ts-exts` option ( #837 ) seemed to work for CLI arguments but not for environment variables.
There are values that merge environment variables and CLI arguments ([index.ts#L197](https://github.com/TypeStrong/ts-node/blob/master/src/index.ts#L197)), but `--prefer-ts-exts` processing seems to use only the values received by CLI.