### PR TITLE
Introduce programTransformers option

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ _Environment variable denoted in parentheses._
 
 ### Programmatic Only Options
 
-* `transformers` An array of transformers to pass to TypeScript
+* `transformers` An object with transformers to pass to TypeScript
+* `programTransformers` A function that accepts a program and return and object with transformers to pass to TypeScript. Not available with `transpileOnly` flag
 * `readFile` Custom TypeScript-compatible file reading function
 * `fileExists` Custom TypeScript-compatible file existence function
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ _Environment variable denoted in parentheses._
 
 ### Programmatic Only Options
 
-* `transformers` An object with transformers to pass to TypeScript
-* `programTransformers` A function that accepts a program and return and object with transformers to pass to TypeScript. Not available with `transpileOnly` flag
+* `transformers` `_ts.CustomTransformers | ((p: _ts.Program) => _ts.CustomTransformers)` An object with transformers or a function that accepts a program and returns an transformers object to pass to TypeScript. Function isn't available with `transpileOnly` flag
 * `readFile` Custom TypeScript-compatible file reading function
 * `fileExists` Custom TypeScript-compatible file existence function
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,7 +297,7 @@ export function register (opts: Options = {}): Register {
     throw new TypeError(`Type information is unavailable without "--type-check"`)
   }
 
-  if (!typeCheck && !!programTransformers) {
+  if (!typeCheck && programTransformers) {
     throw new TypeError(`Program transformers is unavailable without "--type-check"`)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -311,41 +311,35 @@ export function register (opts: Options = {}): Register {
     let program: _ts.Program | undefined = undefined
 
     const getCustomTransformers = (): _ts.CustomTransformers | undefined => {
-      let combinedTransformers: _ts.CustomTransformers | undefined = transformers
-
-      if (programTransformers && program) {
-        const programTransformersData = programTransformers(program)
-
-        if (transformers) {
-          const before = programTransformersData.before && transformers.before
-            ? [...programTransformersData.before, ...transformers.before]
-            : programTransformersData.before
-            ? programTransformersData.before
-            : transformers.before
-
-          const after = programTransformersData.after && transformers.after
-            ? [...programTransformersData.after, ...transformers.after]
-            : programTransformersData.after
-            ? programTransformersData.after
-            : transformers.after
-
-          const afterDeclarations = programTransformersData.afterDeclarations && transformers.afterDeclarations
-            ? [...programTransformersData.afterDeclarations, ...transformers.afterDeclarations]
-            : programTransformersData.afterDeclarations
-            ? programTransformersData.afterDeclarations
-            : transformers.afterDeclarations
-
-          combinedTransformers = {
-            before,
-            after,
-            afterDeclarations
-          }
-        } else {
-          combinedTransformers = programTransformersData
-        }
+      if (!programTransformers || !program) {
+        return transformers
       }
 
-      return combinedTransformers
+      const programTransformersData = programTransformers(program)
+
+      if (!transformers) {
+        return programTransformersData
+      }
+
+      const before = [
+        ...(programTransformersData.before || []),
+        ...(transformers.before || [])
+      ]
+
+      const after = [
+        ...(programTransformersData.after || []),
+        ...(transformers.after || [])
+      ]
+
+      const afterDeclarations = [
+        ...(programTransformersData.afterDeclarations || []),
+        ...(transformers.afterDeclarations || [])
+      ]
+      return {
+        before,
+        after,
+        afterDeclarations
+      }
     }
 
     // Create the compiler host for type checking.


### PR DESCRIPTION
Here's the story, I have a transformer that can generate a runtime validation for json based on a generic type parameter. For that I need to have an access to a type checker, but vanilla transformers can't do that. I came across a solution in `ts-loader`: instead of passing an object literal, you pass a function that accepts a `Program` and should return that object with transformers. So I implemented the same api in `ts-node` considering the backwards compatibility (it's a brand new separate option). While implementing I came across chicken-egg problem cause `LanguageServiceHost` accepts transformers function, but you can only get an access to program once you create a `LanguageService` itself, so i'm kinda using the variable that will be initialized later. It's working, though it can be fragile with different typescript versions.

I'm also not sure about the name of the option `programTransformers`. It doens't sound like a perfect one, but i'm yet to find out the better alternative. @blakeembrey maybe you have some ideas?

Fixes #792 