### PR TITLE
fix: pass the right diagnostics list in transpileOnly mode

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -213,6 +213,18 @@ describe('ts-node', function () {
       })
     })
 
+    it('should throw error even in transpileOnly mode', function (done) {
+      exec(`${BIN_EXEC} --transpile-only -pe "console."`, function (err) {
+        if (err === null) {
+          return done('Command was expected to fail, but it succeeded.')
+        }
+
+        expect(err.message).to.contain('error TS1003: Identifier expected')
+
+        return done()
+      })
+    })
+
     it('should pipe into `ts-node` and evaluate', function (done) {
       const cp = exec(BIN_EXEC, function (err, stdout) {
         expect(err).to.equal(null)

--- a/src/index.ts
+++ b/src/index.ts
@@ -490,7 +490,7 @@ export function create (options: CreateOptions = {}): Register {
         filterDiagnostics(result.diagnostics, ignoreDiagnostics) :
         []
 
-      if (diagnosticList.length) reportTSError(configDiagnosticList)
+      if (diagnosticList.length) reportTSError(diagnosticList)
 
       return [result.outputText, result.sourceMapText as string]
     }


### PR DESCRIPTION
## Description

The wrong `diagnoticList` is passed to `reportTSError`, thus making all errors lacking of any relevant stack trace in `transpileOnly` mode.

I think the origin of that problem is a simple typo. It's currently referencing a variable in the outer scope with a similar name.