### PR TITLE
doc: add precision regarding `--files` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ _Environment variable denoted in parentheses._
 * `-O, --compiler-options [opts]` JSON object to merge with compiler options (`TS_NODE_COMPILER_OPTIONS`)
 * `--dir` Specify working directory for config resolution (`TS_NODE_CWD`, default: `process.cwd()`)
 * `--scope` Scope compiler to files within `cwd` (`TS_NODE_SCOPE`, default: `false`)
-* `--files` Load files from `tsconfig.json` on startup (`TS_NODE_FILES`, default: `false`)
+* `--files` Load `files` and `include`/`exclude` from `tsconfig.json` on startup (`TS_NODE_FILES`, default: `false`)
 * `--pretty` Use pretty diagnostic formatter (`TS_NODE_PRETTY`, default: `false`)
 * `--skip-project` Skip project config resolution and loading (`TS_NODE_SKIP_PROJECT`, default: `false`)
 * `--skip-ignore` Skip ignore checks (`TS_NODE_SKIP_IGNORE`, default: `false`)
@@ -215,7 +215,7 @@ An alternative approach for definitions of third-party libraries are [triple-sla
 import UntypedJsLib from "untyped_js_lib"
 ```
 
-**Tip:** If you _must_ use `files`, enable `--files` flags or set `TS_NODE_FILES=true`.
+**Tip:** If you _must_ use `files` or `include`/`exclude`, enable `--files` flags or set `TS_NODE_FILES=true`.
 
 ## Watching and Restarting
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ _Environment variable denoted in parentheses._
 * `-O, --compiler-options [opts]` JSON object to merge with compiler options (`TS_NODE_COMPILER_OPTIONS`)
 * `--dir` Specify working directory for config resolution (`TS_NODE_CWD`, default: `process.cwd()`)
 * `--scope` Scope compiler to files within `cwd` (`TS_NODE_SCOPE`, default: `false`)
-* `--files` Load `files` and `include`/`exclude` from `tsconfig.json` on startup (`TS_NODE_FILES`, default: `false`)
+* `--files` Load `files`, `include` and `exclude` from `tsconfig.json` on startup (`TS_NODE_FILES`, default: `false`)
 * `--pretty` Use pretty diagnostic formatter (`TS_NODE_PRETTY`, default: `false`)
 * `--skip-project` Skip project config resolution and loading (`TS_NODE_SKIP_PROJECT`, default: `false`)
 * `--skip-ignore` Skip ignore checks (`TS_NODE_SKIP_IGNORE`, default: `false`)
@@ -215,7 +215,7 @@ An alternative approach for definitions of third-party libraries are [triple-sla
 import UntypedJsLib from "untyped_js_lib"
 ```
 
-**Tip:** If you _must_ use `files` or `include`/`exclude`, enable `--files` flags or set `TS_NODE_FILES=true`.
+**Tip:** If you _must_ use `files`, `include`, or `exclude`, enable `--files` flags or set `TS_NODE_FILES=true`.
 
 ## Watching and Restarting
 

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -127,7 +127,7 @@ export function main (argv: string[]) {
 
     --dir                          Specify working directory for config resolution
     --scope                        Scope compiler to files within \`cwd\` only
-    --files                        Load files from \`tsconfig.json\` on startup
+    --files                        Load \`files\`, \`include\` and \`exclude\` from \`tsconfig.json\` on startup
     --pretty                       Use pretty diagnostic formatter (usually enabled by default)
     --skip-project                 Skip reading \`tsconfig.json\`
     --skip-ignore                  Skip \`--ignore\` checks


### PR DESCRIPTION
I suggest to add a little precision about `--files` options, since it does not seem very clear https://github.com/TypeStrong/ts-node/issues/782#issuecomment-561257824