### PR TITLE
Fix bash error in usage example on README page

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ts-node -e 'console.log("Hello, world!")'
 ts-node -p -e '"Hello, world!"'
 
 # Pipe scripts to execute with TypeScript.
-echo "console.log('Hello, world')" | ts-node
+echo 'console.log("Hello, world!")' | ts-node
 ```
 
 ![TypeScript REPL](https://github.com/TypeStrong/ts-node/raw/master/screenshot.png)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ts-node -e 'console.log("Hello, world!")'
 ts-node -p -e '"Hello, world!"'
 
 # Pipe scripts to execute with TypeScript.
-echo "console.log('Hello, world!')" | ts-node
+echo "console.log('Hello, world')" | ts-node
 ```
 
 ![TypeScript REPL](https://github.com/TypeStrong/ts-node/raw/master/screenshot.png)


### PR DESCRIPTION
On Linux bash terminal, executing
`echo "console.log('Hello, world!')"`
gives the following error:
`bash: !': event not found`

To fix the issue, changing the log string from
`Hello, world!` to `Hello, world`

Tested on following systems:
* Ubuntu 18.04.3 LTS
* Linux Mint 19