### PR TITLE
GitHub issue template with repros via GitHub Actions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,9 @@
 ### Expected Behavior
 
 
+
 ### Actual Behavior
+
 
 
 ### Steps to reproduce the problem
@@ -10,18 +12,20 @@
 
 ### Minimal reproduction
 
+
+
 <!--
 
 This link explains why we ask for a minimal reproduction.  Thank you in advance!
 https://gist.github.com/Rich-Harris/88c5fc2ac6dc941b22e7996af05d70ff
 
 You can create a reproduction here:
-https://github.com/cspotcode/ts-node-repros
+https://github.com/TypeStrong/ts-node-repros
 -->
 
 ### Specifications
 
-* ts-node version:
-* node version:
+* ts-node version: 
+* node version: 
 * Operating system and version: 
-* If Windows, are you using WSL or WSL2?:
+* If Windows, are you using WSL or WSL2?: 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+### Expected Behavior
+
+
+### Actual Behavior
+
+
+### Steps to reproduce the problem
+
+
+
+### Minimal reproduction
+
+<!--
+
+This link explains why we ask for a minimal reproduction.  Thank you in advance!
+https://gist.github.com/Rich-Harris/88c5fc2ac6dc941b22e7996af05d70ff
+
+You can create a reproduction here:
+https://github.com/cspotcode/ts-node-repros
+-->
+
+### Specifications
+
+* ts-node version:
+* node version:
+* Operating system and version: 
+* If Windows, are you using WSL or WSL2?:


### PR DESCRIPTION
Related: #492

I had an idea to facilitate repros via Github Actions.

I setup a repository with Github Actions set to run a shell script.  The idea is you can open a PR on that repository, modifying the code however you need to reproduce an issue.  Github Actions will automatically run the reproduction.

One benefit is that reporters don't need to create their own git repository to post a reproduction.  We offer a preconfigured repo for them to fork, paste their code, and push.  Or for really simple cases, people might even be able to post their repro using Github's web UI.

https://github.com/cspotcode/ts-node-repros