### PR TITLE
Add instructions to readme for intellij / webstorm

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,19 +94,11 @@ Create a new node.js configuration, add `-r ts-node/register` to node args and m
 
 **Note:** If you are using the `--project <tsconfig.json>` command line argument as per the [Configuration Options](#configuration-options), and want to apply this same behavior when launching in VS Code, add an "env" key into the launch configuration: `"env": { "TS_NODE_PROJECT": "<tsconfig.json>" }`.
 
-### Intellij (and Webstorm)
+### IntelliJ (and WebStorm)
 
-Run > Edit Configurations > click the plus icon at the top left > Node.js
+Create a new Node.js configuration and add `-r ts-node/register` to "Node parameters."
 
-Node interpreter: node.js (the default should be fine)
-Node parameters: `--inspect=0.0.0.0:9229 --require ts-node/register`
-Working directory: default should be fine
-Javascript file: select the main ts file you want to run. eg: `server/index.ts`
-Application parameters: Extra options for the ts-node process. eg: `--project tsconfig.json`
-Environment variables: `TS_NODE_TRANSPILE_ONLY=true`
-
-Apply and OK
-Click the green triangle at the top of the IntelliJ window to run or the green bug icon to debug.
+**Note:** If you are using the `--project <tsconfig.json>` command line argument as per the [Configuration Options](#configuration-options), and want to apply this same behavior when launching in IntelliJ, specify under "Environment Variables": `TS_NODE_PROJECT=<tsconfig.json>`.
 
 ## How It Works
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ Create a new node.js configuration, add `-r ts-node/register` to node args and m
 
 **Note:** If you are using the `--project <tsconfig.json>` command line argument as per the [Configuration Options](#configuration-options), and want to apply this same behavior when launching in VS Code, add an "env" key into the launch configuration: `"env": { "TS_NODE_PROJECT": "<tsconfig.json>" }`.
 
+### Intellij (and Webstorm)
+
+Run > Edit Configurations > click the plus icon at the top left > Node.js
+
+Node interpreter: node.js (the default should be fine)
+Node parameters: `--inspect=0.0.0.0:9229 --require ts-node/register --require tsconfig-paths/register`
+Working directory: default should be fine
+Javascript file: select the main ts file you want to run. eg: `server\index.ts`
+Application parameters: Extra options for the ts_node process. eg: `--project tsconfig.json --r`
+Environment variables: `TS_NODE_TRANSPILE_ONLY=true`
+
+Apply and OK
+Click the green triangle at the top of the intellij window to run or the green bug icon to debug
+
 ## How It Works
 
 **TypeScript Node** works by registering the TypeScript compiler for `.tsx?` and `.jsx?` (when `allowJs == true`) extensions. When node.js has an extension registered (via `require.extensions`), it will use the extension internally for module resolution. When an extension is unknown to node.js, it handles the file as `.js` (JavaScript). By default, **TypeScript Node** avoids compiling files in `/node_modules/` for three reasons:

--- a/README.md
+++ b/README.md
@@ -99,14 +99,14 @@ Create a new node.js configuration, add `-r ts-node/register` to node args and m
 Run > Edit Configurations > click the plus icon at the top left > Node.js
 
 Node interpreter: node.js (the default should be fine)
-Node parameters: `--inspect=0.0.0.0:9229 --require ts-node/register --require tsconfig-paths/register`
+Node parameters: `--inspect=0.0.0.0:9229 --require ts-node/register`
 Working directory: default should be fine
-Javascript file: select the main ts file you want to run. eg: `server\index.ts`
-Application parameters: Extra options for the ts_node process. eg: `--project tsconfig.json --r`
+Javascript file: select the main ts file you want to run. eg: `server/index.ts`
+Application parameters: Extra options for the ts-node process. eg: `--project tsconfig.json`
 Environment variables: `TS_NODE_TRANSPILE_ONLY=true`
 
 Apply and OK
-Click the green triangle at the top of the intellij window to run or the green bug icon to debug
+Click the green triangle at the top of the IntelliJ window to run or the green bug icon to debug.
 
 ## How It Works
 


### PR DESCRIPTION
based on: https://intellij-support.jetbrains.com/hc/en-us/community/posts/360006528060-New-Webstorm-is-missing-debug-integration-with-Typescript

![image](https://user-images.githubusercontent.com/1710840/74459039-ebfe8200-4e8a-11ea-8362-c935caa99544.png)
