### PR TITLE
Add example for mocha 7, since they removed some watch flags in v7

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,16 @@ You can require `ts-node` and register the loader for future requires by using `
 
 ### Mocha
 
+Mocha 6
+
 ```sh
 mocha --require ts-node/register --watch-extensions ts,tsx "test/**/*.{ts,tsx}" [...args]
+```
+
+Mocha 7
+
+```sh
+mocha --require ts-node/register --extensions ts,tsx --watch --watch-files src 'tests/**/*.{ts,tsx}' [...args]
 ```
 
 **Note:** `--watch-extensions` is only used in `--watch` mode.

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ Mocha 6
 mocha --require ts-node/register --watch-extensions ts,tsx "test/**/*.{ts,tsx}" [...args]
 ```
 
+**Note:** `--watch-extensions` is only used in `--watch` mode.
+
 Mocha 7
 
 ```sh
 mocha --require ts-node/register --extensions ts,tsx --watch --watch-files src 'tests/**/*.{ts,tsx}' [...args]
 ```
-
-**Note:** `--watch-extensions` is only used in `--watch` mode.
 
 ### Tape
 


### PR DESCRIPTION
This adds a mocha example that works for mocha 7.

They removed the --watch-extensions flag in v7.
https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#700--2020-01-05

I asked in #266 if anyone's able to test it, since I don't use mocha's watch mode on any of my projects.