### PR TITLE
Implement getProjectVersion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -538,8 +538,9 @@ export function create (rawOptions: CreateOptions = {}): Register {
         updateMemoryCache(code, fileName)
 
         const programBefore = service.getProgram()
-        if (programBefore !== previousProgram)
-        debug(`compiler rebuilt Program instance when getting output for ${ fileName }`)
+        if (programBefore !== previousProgram) {
+          debug(`compiler rebuilt Program instance when getting output for ${ fileName }`)
+        }
 
         const output = service.getEmitOutput(fileName)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -470,7 +470,7 @@ export function create (rawOptions: CreateOptions = {}): Register {
 
       // Create the compiler host for type checking.
       const serviceHost: _ts.LanguageServiceHost = {
-        getProjectVersion: () => `${ projectVersion }`,
+        getProjectVersion: () => String(projectVersion),
         getScriptFileNames: () => rootFileNames,
         getScriptVersion: (fileName: string) => {
           const version = fileVersions.get(fileName)


### PR DESCRIPTION
Due to Microsoft/TypeScript#36748, TypeScript's language service always thinks the `Program` is out-of-date and rebuilds it 3 times for every `.ts` file that we load: once each for `getEmitOutput`, `getSemanticDiagnostics`, and `getSyntacticDiagnostics`.

We can workaround this bug by implementing `getProjectVersion`.  If `getProjectVersion` stays the same, TypeScript will reuse the existing `Program`.  It'll still need to be rebuilt every time we modify the rootFiles array, but that's only once instead of 3 times.

I also added debug log statements that double-check when the `Program` instance is rebuilt.  This should be helpful if we ask for TS_NODE_DEBUG logs from users.