### PR TITLE
Fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,3 +1,4 @@
+---
 name: 'Bug report'
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,3 +1,4 @@
+---
 name: 'Feature request'
 ---
 


### PR DESCRIPTION
The front-matter on issue templates was missing a starting `---` delimiter, so they weren't working.  My mistake.