### PR TITLE
Strip ts-node callstack from reported error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -423,6 +423,13 @@ export function create (rawOptions: CreateOptions = {}): Register {
 
   function reportTSError (configDiagnosticList: _ts.Diagnostic[]) {
     const error = createTSError(configDiagnosticList)
+
+    const stackLines = error.stack.split('\n')
+    const lastLine = stackLines.findIndex(line => line.includes('ts-node'))
+    if (lastLine !== -1) {
+      error.stack = stackLines.slice(0, lastLine).join('\n');
+    }
+
     if (options.logError) {
       // Print error in red color and continue execution.
       console.error('\x1b[31m%s\x1b[0m', error)


### PR DESCRIPTION
Hi!

I am a big fan of this library.

For years now I have applied this patch by hand to local copies of this module, since I use small terminal panes and the traceback generally means I have to scroll up to see any errors.

With this patch, the traceback is removed from the reported error.

I have been using this for a few years with no issues, but it could probably use improving if it were to be included.

Figured I would just send this your way in case it appeals to the team of maintainers. 