### PR TITLE
change order of npm installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@
 
 ```sh
 # Locally in your project.
-npm install -D ts-node
 npm install -D typescript
+npm install -D ts-node
 
 # Or globally with TypeScript.
-npm install -g ts-node
 npm install -g typescript
+npm install -g ts-node
 ```
 
 **Tip:** Installing modules locally allows you to control and share the versions through `package.json`. TS Node will always resolve the compiler from `cwd` before checking relative to its own installation.


### PR DESCRIPTION
After attempting to copy/paste local installs, I hit an error. ts-node requires a peer dependency of typescript. Therefore, I had to install typescript before ts-node for it successfully install. It makes sense to order these appropriately in the README.