### PR TITLE
Add timestamp to debug logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,11 @@ function yn (value: string | undefined) {
  * Debugging `ts-node`.
  */
 const shouldDebug = yn(process.env.TS_NODE_DEBUG)
-const debug = shouldDebug ? console.log.bind(console, 'ts-node') : () => undefined
+const timestamp = function(){};
+timestamp.toString = function(){
+  return "[ts-node " + (new Date).toISOString() + "]";
+}
+const debug = shouldDebug ? console.log.bind(console, '%s', timestamp) : () => undefined
 const debugFn = shouldDebug ?
   <T, U> (key: string, fn: (arg: T) => U) => {
     let i = 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,9 @@ function yn (value: string | undefined) {
  * Debugging `ts-node`.
  */
 const shouldDebug = yn(process.env.TS_NODE_DEBUG)
-const timestamp = function(){};
-timestamp.toString = function(){
-  return "[ts-node " + (new Date).toISOString() + "]";
-}
-const debug = shouldDebug ? console.log.bind(console, '%s', timestamp) : () => undefined
+const debug = shouldDebug ? 
+  (...args: any) => console.log("ts-node " + (new Date).toISOString(), ...args) 
+  : () => undefined;
 const debugFn = shouldDebug ?
   <T, U> (key: string, fn: (arg: T) => U) => {
     let i = 0

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ function yn (value: string | undefined) {
  */
 const shouldDebug = yn(process.env.TS_NODE_DEBUG)
 const debug = shouldDebug ?
-  (...args: any) => console.log(`ts-node ${new Date().toISOString()}`, ...args)
+  (...args: any) => console.log(`[ts-node ${new Date().toISOString()}]`, ...args)
   : () => undefined
 const debugFn = shouldDebug ?
   <T, U> (key: string, fn: (arg: T) => U) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,9 +38,9 @@ function yn (value: string | undefined) {
  * Debugging `ts-node`.
  */
 const shouldDebug = yn(process.env.TS_NODE_DEBUG)
-const debug = shouldDebug ? 
-  (...args: any) => console.log("ts-node " + (new Date).toISOString(), ...args) 
-  : () => undefined;
+const debug = shouldDebug ?
+  (...args: any) => console.log(`ts-node ${new Date().toISOString()}`, ...args)
+  : () => undefined
 const debugFn = shouldDebug ?
   <T, U> (key: string, fn: (arg: T) => U) => {
     let i = 0


### PR DESCRIPTION
This PR add timestamp for debug logging.

example output is 
```
[ts-node 2020-04-02T12:35:37.097Z] directoryExists c/ts-node/node_modules/events 13
``` 

Associated with https://github.com/TypeStrong/ts-node/issues/754#issuecomment-606677376