### PR TITLE
Normalized filename in cache

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -507,18 +507,17 @@ export function create (rawOptions: CreateOptions = {}): Register {
       const service = ts.createLanguageService(serviceHost, registry)
 
       const updateMemoryCache = (contents: string, fileName: string) => {
-        const normalizedFileName = normalizeSlashes(fileName)
         // Add to `rootFiles` when discovered for the first time.
-        if (!fileVersions.has(normalizedFileName)) {
-          rootFileNames.push(normalizedFileName)
+        if (!fileVersions.has(fileName)) {
+          rootFileNames.push(fileName)
         }
 
-        const previousVersion = fileVersions.get(normalizedFileName) || 0
-        const previousContents = fileContents.get(normalizedFileName)
+        const previousVersion = fileVersions.get(fileName) || 0
+        const previousContents = fileContents.get(fileName)
         // Avoid incrementing cache when nothing has changed.
         if (contents !== previousContents) {
-          fileVersions.set(normalizedFileName, previousVersion + 1)
-          fileContents.set(normalizedFileName, contents)
+          fileVersions.set(fileName, previousVersion + 1)
+          fileContents.set(fileName, contents)
           // Increment project version for every file change.
           projectVersion++
         }
@@ -634,14 +633,13 @@ export function create (rawOptions: CreateOptions = {}): Register {
 
       // Set the file contents into cache manually.
       const updateMemoryCache = (contents: string, fileName: string) => {
-        const normalizedFileName = normalizeSlashes(fileName)
-        const sourceFile = builderProgram.getSourceFile(normalizedFileName)
+        const sourceFile = builderProgram.getSourceFile(fileName)
 
-        fileContents.set(normalizedFileName, contents)
+        fileContents.set(fileName, contents)
 
         // Add to `rootFiles` when discovered by compiler for the first time.
         if (sourceFile === undefined) {
-          rootFileNames.push(normalizedFileName)
+          rootFileNames.push(fileName)
         }
 
         // Update program when file changes.
@@ -756,8 +754,9 @@ export function create (rawOptions: CreateOptions = {}): Register {
 
   // Create a simple TypeScript compiler proxy.
   function compile (code: string, fileName: string, lineOffset = 0) {
-    const [value, sourceMap] = getOutput(code, fileName, lineOffset)
-    const output = updateOutput(value, fileName, sourceMap, getExtension)
+    const normalizedFileName = normalizeSlashes(fileName)
+    const [value, sourceMap] = getOutput(code, normalizedFileName, lineOffset)
+    const output = updateOutput(value, normalizedFileName, sourceMap, getExtension)
     outputCache.set(fileName, output)
     return output
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -507,17 +507,18 @@ export function create (rawOptions: CreateOptions = {}): Register {
       const service = ts.createLanguageService(serviceHost, registry)
 
       const updateMemoryCache = (contents: string, fileName: string) => {
+        const normalizedFileName = normalizeSlashes(fileName)
         // Add to `rootFiles` when discovered for the first time.
-        if (!fileVersions.has(fileName)) {
-          rootFileNames.push(fileName)
+        if (!fileVersions.has(normalizedFileName)) {
+          rootFileNames.push(normalizedFileName)
         }
 
-        const previousVersion = fileVersions.get(fileName) || 0
-        const previousContents = fileContents.get(fileName)
+        const previousVersion = fileVersions.get(normalizedFileName) || 0
+        const previousContents = fileContents.get(normalizedFileName)
         // Avoid incrementing cache when nothing has changed.
         if (contents !== previousContents) {
-          fileVersions.set(fileName, previousVersion + 1)
-          fileContents.set(fileName, contents)
+          fileVersions.set(normalizedFileName, previousVersion + 1)
+          fileContents.set(normalizedFileName, contents)
           // Increment project version for every file change.
           projectVersion++
         }
@@ -633,13 +634,14 @@ export function create (rawOptions: CreateOptions = {}): Register {
 
       // Set the file contents into cache manually.
       const updateMemoryCache = (contents: string, fileName: string) => {
-        const sourceFile = builderProgram.getSourceFile(fileName)
+        const normalizedFileName = normalizeSlashes(fileName)
+        const sourceFile = builderProgram.getSourceFile(normalizedFileName)
 
-        fileContents.set(fileName, contents)
+        fileContents.set(normalizedFileName, contents)
 
         // Add to `rootFiles` when discovered by compiler for the first time.
         if (sourceFile === undefined) {
-          rootFileNames.push(fileName)
+          rootFileNames.push(normalizedFileName)
         }
 
         // Update program when file changes.


### PR DESCRIPTION
Fix https://github.com/TypeStrong/ts-node/issues/754#issuecomment-606666075

These changes make the filename used to index the cache normalized.

Tested on windows only on https://github.com/sylc/ts-node-debug