### PR TITLE
Add missing recovery code

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -467,6 +467,7 @@ function lineCount (value: string) {
 const RECOVERY_CODES: Set<number> = new Set([
   1003, // "Identifier expected."
   1005, // "')' expected."
+  1007, // "The parser expected to find a '}' to match the '{' token here."
   1109, // "Expression expected."
   1126, // "Unexpected end of text."
   1160, // "Unterminated template literal."


### PR DESCRIPTION
In TypeScript 3.8 there exists a recovery code 1007 for missing braces, which is used for expressions such as:
```
  async function main() {
```

Add this code to `RECOVERY_CODES` to improve the interactive (REPL) experience.
