### PR TITLE
Fix failing tests caused by recent changes to @types/node

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -596,7 +596,7 @@ describe('ts-node', function () {
             return _compile.call(this, code, fileName)
           }
 
-          return old(m, fileName)
+          return old!(m, fileName)
         }
       })
 


### PR DESCRIPTION
Caused by https://github.com/DefinitelyTyped/DefinitelyTyped/commit/f7e28122e559359aeb1dd37b93ed74a155100f36

`require.extensions[string]` is possibly `undefined`