### PR TITLE
Fix interactive flag so that it forces REPL even when stdin is not a tty

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -227,7 +227,8 @@ export function main (argv: string[]) {
       Module.runMain()
     } else {
       // Piping of execution _only_ occurs when no other script is specified.
-      if (process.stdin.isTTY) {
+      // --interactive flag forces REPL
+      if (interactive || process.stdin.isTTY) {
         startRepl(service, state, code)
       } else {
         let buffer = code || ''

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -260,6 +260,21 @@ describe('ts-node', function () {
       cp.stdin!.end('true')
     })
 
+    it('should run REPL when --interactive passed and stdin is not a TTY', function (done) {
+      const cp = exec(`${cmd} --interactive`, function (err, stdout) {
+        expect(err).to.equal(null)
+        expect(stdout).to.equal(
+          '> 123\n' +
+          'undefined\n' +
+          '> '
+        )
+        return done()
+      })
+
+      cp.stdin!.end('console.log("123")\n')
+
+    })
+
     it('should support require flags', function (done) {
       exec(`${cmd} -r ./tests/hello-world -pe "console.log('success')"`, function (err, stdout) {
         expect(err).to.equal(null)


### PR DESCRIPTION
Fixes #1013 

There's a bug with the `--interactive` / `-i` flag where it does not launch the REPL when stdin is not a tty.

This fix makes our behavior match node's `-i` flag and our help docs.