### PR TITLE
Make shebang example local installation compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ ts-node-transpile-only scripts.ts
 ### Shebang
 
 ```typescript
-#!/usr/bin/env ts-node-script
+#!/usr/bin/env npx ts-node-script
 
 console.log("Hello, world!")
 ```


### PR DESCRIPTION
`#!/usr/bin/env ts-node-script` shebang assumes you have ts-node installed globally, `#!/usr/bin/env npx ts-node-script` assumes you have npm version 5.2 or higher. I prefer the second assumption a bit more.