### PR TITLE
Fix package.json exports for `ts-node/register`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,16 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
-    "./esm": "./esm.mjs"
+    "./esm": "./esm.mjs",
+    "./register": "./register/index.js",
+    "./register/index": "./register/index.js",
+    "./register/index.js": "./register/index.js",
+    "./register/files": "./register/files.js",
+    "./register/files.js": "./register/files.js",
+    "./register/transpile-only": "./register/transpile-only.js",
+    "./register/transpile-only.js": "./register/transpile-only.js",
+    "./register/type-check": "./register/type-check.js",
+    "./register/type-check.js": "./register/type-check.js"
   },
   "types": "dist/index.d.ts",
   "bin": {


### PR DESCRIPTION
Commit f6cd5d4d696e broke `require('ts-node/register')` because
`exports:` provides an *exclusive* list of possible entry points,
and makes importing through other entry points impossible.

In particular, this breaks node-tap with TypeScript support.

Refs: https://medium.com/@forbeslindesay/is-promise-post-mortem-cab807f18dcc

@cspotcode Would be cool to see a release very very soon in order to un-break CI for lots of people :)