### PR TITLE
Run ci only once per pull request commit and per master commit

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,7 +1,9 @@
 name: Continuous Integration
 on:
   # branches pushed by collaborators
-  push: {}
+  push:
+    branches:
+      - master
   # pull request from non-collaborators
   pull_request: {}
   # nightly


### PR DESCRIPTION
With how big the test matrix is, we were running it all twice for each commit to a pull request.  This change runs CI only against pull requests and against contributor commits to master.  We can open draft pull requests for work in progress when we want to run CI against a non-master branch.