### PR TITLE
Fix coverage reporting when tests fail; also push to codecov

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,12 +105,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: ci-artifacts/
-      - run: npm run ci-coverage-report
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
+          parallel-finish: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -85,6 +85,13 @@ jobs:
       - run: npm run test-cov
       - run: npm run coverage-report
         if: ${{ always() }}
+      - name: Codecov
+        if: ${{ always() }}
+        uses: codecov/codecov-action@v1
+        with:
+          flags: ${{ matrix.os }},${{ matrix.node }},${{ matrix.typescript }}
+      - run: npm run coverage-fix-paths
+      - run: npm run coverage-report
       - name: Coveralls
         if: ${{ always() }}
         uses: coverallsapp/github-action@master
@@ -92,13 +99,6 @@ jobs:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.os }}-${{ matrix.flavor }}
           parallel: true
-      - name: Codecov
-        if: ${{ always() }}
-        uses: codecov/codecov-action@v1
-        with:
-          flags: ${{ matrix.os }},${{ matrix.node }},${{ matrix.typescript }}
-          # name: codecov-umbrella # optional
-          # fail_ci_if_error: true # optional (default = false)
   finish:
     needs: test
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,38 +33,54 @@ jobs:
 
   test:
     needs: lint-build
-    name: "Test #${{ matrix.flavor }}: ${{ matrix.os }}, node v${{ matrix.node }}, ${{ matrix.typescript }}"
-    runs-on: ${{ matrix.os }}
+    name: "Test: ${{ matrix.os }}, node ${{ matrix.node }}, TS ${{ matrix.typescript }}"
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu, windows]
         flavor: [1, 2, 3, 4, 5, 6, 7, 8]
         include:
           - flavor: 1
             node: 10
-            typescript: typescript@latest
+            nodeFlag: 10
+            typescript: latest
+            typescriptFlag: latest
           - flavor: 2
             node: 12
-            typescript: typescript@latest
+            nodeFlag: 12
+            typescript: latest
+            typescriptFlag: latest
           - flavor: 3
             node: 13
-            typescript: typescript@latest
+            nodeFlag: 13
+            typescript: latest
+            typescriptFlag: latest
           - flavor: 4
             node: 13
-            typescript: typescript@2.7
+            nodeFlag: 13
+            typescript: 2.7
+            typescriptFlag: 2_7
           - flavor: 5
             node: 13
-            typescript: typescript@next
+            nodeFlag: 13
+            typescript: next
+            typescriptFlag: next
           - flavor: 6
             node: 14
-            typescript: typescript@latest
+            nodeFlag: 14
+            typescript: latest
+            typescriptFlag: latest
           - flavor: 7
             node: 14
-            typescript: typescript@2.7
+            nodeFlag: 14
+            typescript: 2.7
+            typescriptFlag: 2_7
           - flavor: 8
             node: 14
-            typescript: typescript@next
+            nodeFlag: 14
+            typescript: next
+            typescriptFlag: next
     steps:
       # checkout code
       - uses: actions/checkout@v2
@@ -81,7 +97,7 @@ jobs:
         with:
           name: ts-node-packed.tgz
           path: tests/
-      - run: npm install ${{ matrix.typescript }} --force
+      - run: npm install typescript@${{ matrix.typescript }} --force
       - run: npm run test-cov
       - run: npm run coverage-report
         if: ${{ always() }}
@@ -89,7 +105,7 @@ jobs:
         if: ${{ always() }}
         uses: codecov/codecov-action@v1
         with:
-          flags: ${{ matrix.os }},node${{ matrix.node }},${{ matrix.typescript }}
+          flags: ${{ matrix.os }},node_${{ matrix.nodeFlag }},typescript_${{ matrix.typescriptFlag }}
       - run: npm run coverage-fix-paths
       - run: npm run coverage-report
       - name: Coveralls
@@ -97,7 +113,6 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ matrix.os }}-${{ matrix.flavor }}
           parallel: true
   finish:
     needs: test

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -105,7 +105,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
-      - name: Coveralls
+      - name: Coveralls Finished
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -83,6 +83,8 @@ jobs:
           path: tests/
       - run: npm install ${{ matrix.typescript }} --force
       - run: npm run test-cov
+      - run: npm run coverage-report
+        if: ${{ always() }}
       - name: Coveralls
         if: ${{ always() }}
         uses: coverallsapp/github-action@master
@@ -90,13 +92,25 @@ jobs:
           github-token: ${{ secrets.github_token }}
           flag-name: run-${{ matrix.os }}-${{ matrix.flavor }}
           parallel: true
+      - name: Codecov
+        if: ${{ always() }}
+        uses: codecov/codecov-action@v1
+        with:
+          # file: ./coverage/lcov.info
+          # flags: unittests # optional
+          # name: codecov-umbrella # optional
+          # fail_ci_if_error: true # optional (default = false)
   finish:
     needs: test
     runs-on: ubuntu-latest
     if: ${{ always() }}
     steps:
-      - name: Coveralls Finished
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: ci-artifacts/
+      - run: npm run ci-coverage-report
+      - name: Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
-          parallel-finished: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ always() }}
         uses: codecov/codecov-action@v1
         with:
-          flags: ${{ matrix.os }},${{ matrix.node }},${{ matrix.typescript }}
+          flags: ${{ matrix.os }},node${{ matrix.node }},${{ matrix.typescript }}
       - run: npm run coverage-fix-paths
       - run: npm run coverage-report
       - name: Coveralls

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -95,9 +95,8 @@ jobs:
       - name: Codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@v1
-        # with:
-          # file: ./coverage/lcov.info
-          # flags: unittests # optional
+        with:
+          flags: ${{ matrix.os }},${{ matrix.node }},${{ matrix.typescript }}
           # name: codecov-umbrella # optional
           # fail_ci_if_error: true # optional (default = false)
   finish:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -109,4 +109,4 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
-          parallel-finish: true
+          parallel-finished: true

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Codecov
         if: ${{ always() }}
         uses: codecov/codecov-action@v1
-        with:
+        # with:
           # file: ./coverage/lcov.info
           # flags: unittests # optional
           # name: codecov-umbrella # optional

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,4 @@
-coverage:
-  status:
-    project:
-      default:
-        # basic
-        target: auto
-        threshold: 0%
-        base: auto
-       # advanced
-        branches:
-          - master
-        if_not_found: success
-        if_ci_failed: error
-        informational: false
-        only_pulls: false
+fixes:
+  # Remap from npm-installed ts-node to root of project
+  # This can take the place of ./scripts/rewrite-coverage-paths.js
+  - "tests/node_modules/ts-node/::"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 0%
+        base: auto
+       # advanced
+        branches:
+          - master
+        if_not_found: success
+        if_ci_failed: error
+        informational: false
+        only_pulls: false

--- a/package.json
+++ b/package.json
@@ -30,8 +30,9 @@
     "build-pack": "node ./scripts/build-pack.js",
     "test-spec": "mocha dist/**/*.spec.js -R spec --bail",
     "test-cov": "nyc mocha -- \"dist/**/*.spec.js\" -R spec --bail",
-    "coverage-report": "node ./scripts/rewrite-coverage-paths.js && nyc report --reporter=lcov",
     "test": "npm run build && npm run lint && npm run test-cov",
+    "coverage-fix-paths": "node ./scripts/rewrite-coverage-paths.js",
+    "coverage-report": "nyc report --reporter=lcov",
     "prepare": "npm run build-nopack"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "build-configSchema": "typescript-json-schema --topRef --refs --validationKeywords allOf --out tsconfig.schema.json tsconfig.json TsConfigSchema && node --require ./register ./scripts/create-merged-schema",
     "build-pack": "node ./scripts/build-pack.js",
     "test-spec": "mocha dist/**/*.spec.js -R spec --bail",
-    "test-cov": "nyc mocha -- \"dist/**/*.spec.js\" -R spec --bail && node ./scripts/rewrite-coverage-paths.js && nyc report --reporter=lcov",
+    "test-cov": "nyc mocha -- \"dist/**/*.spec.js\" -R spec --bail",
+    "coverage-report": "node ./scripts/rewrite-coverage-paths.js && nyc report --reporter=lcov",
     "test": "npm run build && npm run lint && npm run test-cov",
     "prepare": "npm run build-nopack"
   },


### PR DESCRIPTION
codecov has path rewriting built-in so we do not need a custom `./scripts/rewrite-coverage-paths.js`.

It might not exhibit the weird issues I'm seeing with coveralls' Github Actions integration.

Merging to master so we can get some coverage data from master into Codecov and see if it behaves nicely on pull requests.