### PR TITLE
fix: pass transformers object to ts.transpileModule method (Fixes #1051)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -488,10 +488,15 @@ export function create (rawOptions: CreateOptions = {}): Register {
   let getTypeInfo: (_code: string, _fileName: string, _position: number) => TypeInfo
 
   const getOutputTranspileOnly = (code: string, fileName: string, overrideCompilerOptions?: Partial<_ts.CompilerOptions>): SourceOutput => {
+    if (typeof transformers === 'function') {
+      throw new TypeError('Transformers function is unavailable in "--transpile-only"')
+    }
+
     const result = ts.transpileModule(code, {
       fileName,
       compilerOptions: overrideCompilerOptions ? { ...config.options, ...overrideCompilerOptions } : config.options,
-      reportDiagnostics: true
+      reportDiagnostics: true,
+      transformers: transformers
     })
 
     const diagnosticList = filterDiagnostics(result.diagnostics || [], ignoreDiagnostics)
@@ -785,10 +790,6 @@ export function create (rawOptions: CreateOptions = {}): Register {
       }
     }
   } else {
-    if (typeof transformers === 'function') {
-      throw new TypeError('Transformers function is unavailable in "--transpile-only"')
-    }
-
     getOutput = getOutputTranspileOnly
 
     getTypeInfo = () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -488,15 +488,11 @@ export function create (rawOptions: CreateOptions = {}): Register {
   let getTypeInfo: (_code: string, _fileName: string, _position: number) => TypeInfo
 
   const getOutputTranspileOnly = (code: string, fileName: string, overrideCompilerOptions?: Partial<_ts.CompilerOptions>): SourceOutput => {
-    if (typeof transformers === 'function') {
-      throw new TypeError('Transformers function is unavailable in "--transpile-only"')
-    }
-
     const result = ts.transpileModule(code, {
       fileName,
       compilerOptions: overrideCompilerOptions ? { ...config.options, ...overrideCompilerOptions } : config.options,
       reportDiagnostics: true,
-      transformers: transformers
+      transformers: transformers as Exclude<typeof transformers, Function>
     })
 
     const diagnosticList = filterDiagnostics(result.diagnostics || [], ignoreDiagnostics)
@@ -790,6 +786,10 @@ export function create (rawOptions: CreateOptions = {}): Register {
       }
     }
   } else {
+    if (typeof transformers === 'function') {
+      throw new TypeError('Transformers function is unavailable in "--transpile-only"')
+    }
+
     getOutput = getOutputTranspileOnly
 
     getTypeInfo = () => {


### PR DESCRIPTION
As per the README, only the `transformers factory function` is not allowed during the `transpileOnly` module. However, an object can still be passed.

In this PR https://github.com/TypeStrong/ts-node/pull/879/files#diff-f41e9d04a45c83f3b6f6e630f10117feR383, the code already guards against the factory function, but doesn't pass the transformers to the `transpileModule` method.

Related issue https://github.com/TypeStrong/ts-node/issues/1051