### PR TITLE
Add helpful links to "Create issue" page, directing people to Discord, StackOverflow, etc

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -14,5 +14,5 @@ contact_links:
     url: "https://github.com/TypeStrong/ts-node/blob/master/README.md#help-my-types-are-missing"
   - 
     name: "TSError or SyntaxError"
-    about: "These errors come from TypeScript and node, respectively"
+    about: "These errors come from TypeScript and node, respectively.  Use StackOverflow or Discord for usage and configuration help."
     url: "https://stackoverflow.com/questions/tagged/ts-node"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -13,6 +13,6 @@ contact_links:
     about: "This is likely a configuration problem.  Check our README"
     url: "https://github.com/TypeStrong/ts-node/blob/master/README.md#help-my-types-are-missing"
   - 
-    about: "These errors come from TypeScript and node, respectively"
     name: "TSError or SyntaxError"
+    about: "These errors come from TypeScript and node, respectively"
     url: "https://stackoverflow.com/questions/tagged/ts-node"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,18 @@
+--- 
+contact_links: 
+  - 
+    name: Question
+    about: "Please ask and answer usage questions on Stack Overflow."
+    url: "https://stackoverflow.com/questions/tagged/ts-node"
+  - 
+    name: Chat
+    about: "Alternatively, you can use the TypeScript Community Discord."
+    url: "https://discord.gg/typescript"
+  - 
+    name: "Help! My Types Are Missing!"
+    about: "This is likely a configuration problem.  Check our README"
+    url: "https://github.com/TypeStrong/ts-node/blob/master/README.md#help-my-types-are-missing"
+  - 
+    about: "These errors come from TypeScript and node, respectively"
+    name: "TSError or SyntaxError"
+    url: "https://stackoverflow.com/questions/tagged/ts-node"


### PR DESCRIPTION
I took inspiration from TypeScript's issue tracker configuration
https://github.com/microsoft/TypeScript/blob/master/.github/ISSUE_TEMPLATE/config.yml

Which looks like this:
https://github.com/microsoft/TypeScript/issues/new/choose
