### PR TITLE
Add mocharc file for better editor support

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  spec: ['dist/**/*.spec.js']
+};


### PR DESCRIPTION
Declaring mocha options in a standard config file enables editors to do their thing.

For example:

![image](https://user-images.githubusercontent.com/376504/89922960-d2d25600-dbcd-11ea-8649-b3f0a206faaf.png)
