### PR TITLE
fix broken tests

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -584,7 +584,6 @@ describe('ts-node', function () {
       moduleTestPath = require.resolve('../tests/module')
     })
 
-
     afterEach(() => {
       // Re-enable project after every test.
       registered.enabled(true)

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -573,6 +573,7 @@ describe('ts-node', function () {
 
   describe('register', function () {
     let registered: tsNodeTypes.Register
+    let moduleTestPath: string
     before(() => {
       registered = register({
         project: PROJECT,
@@ -580,9 +581,9 @@ describe('ts-node', function () {
           jsx: 'preserve'
         }
       })
+      moduleTestPath = require.resolve('../tests/module')
     })
 
-    const moduleTestPath = require.resolve('../tests/module')
 
     afterEach(() => {
       // Re-enable project after every test.


### PR DESCRIPTION
Some logic wasn't wrapped in a before() hook so if you used --fgrep then tests would fail.  Probably a race condition where another test was installing the require() hooks.