### PR TITLE
WIP REPL tab completion

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -2,7 +2,7 @@
 
 import { join, resolve, dirname } from 'path'
 import { start, Recoverable } from 'repl'
-import { inspect } from 'util'
+import { inspect, callbackify } from 'util'
 import Module = require('module')
 import arg = require('arg')
 import { diffLines } from 'diff'
@@ -10,6 +10,8 @@ import { Script } from 'vm'
 import { readFileSync, statSync, realpathSync } from 'fs'
 import { homedir } from 'os'
 import { VERSION, TSError, parse, Register, register } from './index'
+import { CompleterResult } from 'readline'
+import { compare } from 'semver'
 
 /**
  * Eval filename for REPL/debug.
@@ -366,7 +368,10 @@ function startRepl (service: Register, state: EvalState, code?: string) {
     // Mimicking node's REPL implementation: https://github.com/nodejs/node/blob/168b22ba073ee1cbf8d0bcb4ded7ff3099335d04/lib/internal/repl.js#L28-L30
     terminal: process.stdout.isTTY && !parseInt(process.env.NODE_NO_READLINE!, 10),
     eval: replEval,
-    useGlobal: true
+    useGlobal: true,
+    completer: completer,
+    // completer: callbackify(asyncCompleter),
+    preview: true
   })
 
   /**
@@ -398,6 +403,16 @@ function startRepl (service: Register, state: EvalState, code?: string) {
     }
 
     return callback(err, result)
+  }
+
+  function completer(input: string): CompleterResult {
+    const undo = appendEval(state, input)
+    const { completions, context } = service.getCompletions(state.input, state.path, state.input.length)
+    undo()
+    return [completions, context]
+  }
+  async function asyncCompleter(line: string): Promise<CompleterResult> {
+    return [['prefixfoo', 'prefixbar', 'prefixbaz'], line]
   }
 
   // Bookmark the point where we should reset the REPL state.

--- a/src/index.ts
+++ b/src/index.ts
@@ -262,6 +262,11 @@ export interface TypeInfo {
   comment: string
 }
 
+export interface Completions {
+  completions: string[],
+  context: string
+}
+
 /**
  * Default register options, including values specified via environment
  * variables.
@@ -349,6 +354,7 @@ export interface Register {
   ignored (fileName: string): boolean
   compile (code: string, fileName: string, lineOffset?: number): string
   getTypeInfo (code: string, fileName: string, position: number): TypeInfo
+  getCompletions (code: string, fileName: string, position: number): Completions
 }
 
 /**
@@ -514,6 +520,15 @@ export function create (rawOptions: CreateOptions = {}): Register {
    */
   let getOutput: (code: string, fileName: string) => SourceOutput
   let getTypeInfo: (_code: string, _fileName: string, _position: number) => TypeInfo
+  let getCompletions: (_code: string, _fileName: string, _position: number) => Completions
+
+  const getEmptyCompletions = (code: string, fileName: string, position: number) => {
+    // throw new Error('not implemented')
+    return {
+      completions: [],
+      context: ''
+    }
+  }
 
   // Use full language services when the fast option is disabled.
   if (!transpileOnly) {
@@ -647,6 +662,20 @@ export function create (rawOptions: CreateOptions = {}): Register {
         const comment = ts.displayPartsToString(info ? info.documentation : [])
 
         return { name, comment }
+      }
+
+      getCompletions = (code: string, fileName: string, position: number) => {
+        updateMemoryCache(code, fileName)
+
+        // https://github.com/microsoft/monaco-typescript/blob/e623bb9f76c8376b433e7f1c30fec5a5d7abd4d1/src/languageFeatures.ts#L274-L309
+        const trailingWordLength = code.slice(0, position).match(/\s*[a-zA-Z0-9_$]+\s*$/)?.[0].length ?? 0
+
+        const info = service.getCompletionsAtPosition(fileName, position, {includeCompletionsWithInsertText: true})
+        const entries = info?.entries.filter(entry => !entry.hasAction && !entry.replacementSpan) ?? []
+        return {
+          completions: entries.map(entry => entry.name),
+          context: code.slice(position - trailingWordLength, position)
+        }
       }
     } else {
       const sys = {
@@ -791,6 +820,8 @@ export function create (rawOptions: CreateOptions = {}): Register {
         }
       }
 
+      getCompletions = getEmptyCompletions
+
       // Write `.tsbuildinfo` when `--build` is enabled.
       if (options.emit && config.options.incremental) {
         process.on('exit', () => {
@@ -821,6 +852,8 @@ export function create (rawOptions: CreateOptions = {}): Register {
     getTypeInfo = () => {
       throw new TypeError('Type information is unavailable in "--transpile-only"')
     }
+
+    getCompletions = getEmptyCompletions
   }
 
   // Create a simple TypeScript compiler proxy.
@@ -845,7 +878,7 @@ export function create (rawOptions: CreateOptions = {}): Register {
     return true
   }
 
-  return { ts, config, compile, getTypeInfo, ignored, enabled, options }
+  return { ts, config, compile, getTypeInfo, getCompletions, ignored, enabled, options }
 }
 
 /**


### PR DESCRIPTION
Took a quick stab at completions in the REPL.

Issues:

first time you get tab completions, the input line freezes while the language service spins up.  We'd probably want to force it to spin up before the first prompt is shown

TS tab completions sometimes replace already-entered text.  For example, they may propose rewriting `.f` into `?.foo`  Node's built-in completion doesn't support this.  Is it worth using a third-party library?  Does one exist with the features we need?
