### PR TITLE
fix: Alias --es-module-specifier-resolution to --experimental-specifier-resolution for Node 12 compatibility

### DIFF
--- a/dist-raw/node-options.js
+++ b/dist-raw/node-options.js
@@ -25,7 +25,8 @@ function parseArgv(argv) {
     '--preserve-symlinks': Boolean,
     '--preserve-symlinks-main': Boolean,
     '--input-type': String,
-    '--experimental-specifier-resolution': String
+    '--experimental-specifier-resolution': String,
+    '--es-module-specifier-resolution': '--experimental-specifier-resolution',
   }, {
     argv,
     permissive: true

--- a/dist-raw/node-options.js
+++ b/dist-raw/node-options.js
@@ -26,6 +26,7 @@ function parseArgv(argv) {
     '--preserve-symlinks-main': Boolean,
     '--input-type': String,
     '--experimental-specifier-resolution': String,
+    // Legacy alias for node versions prior to 12.16
     '--es-module-specifier-resolution': '--experimental-specifier-resolution',
   }, {
     argv,

--- a/esm-usage-example/package.json
+++ b/esm-usage-example/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "ts-node": "github:TypeStrong/ts-node#ab/esm-support",
+    "ts-node": "github:TypeStrong/ts-node#master",
     "typescript": "^3.8.3"
   }
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -887,6 +887,14 @@ describe('ts-node', function () {
             return done()
           })
         })
+        it('via --es-module-specifier-resolution alias', (done) => {
+          exec(`${cmd} --experimental-modules --es-module-specifier-resolution=node index.ts`, { cwd: join(__dirname, '../tests/esm-node-resolver') }, function (err, stdout) {
+            expect(err).to.equal(null)
+            expect(stdout).to.equal('foo bar baz biff\n')
+
+            return done()
+          })
+        })
         it('via NODE_OPTIONS', (done) => {
           exec(`${cmd} index.ts`, {
             cwd: join(__dirname, '../tests/esm-node-resolver'),


### PR DESCRIPTION
Context here: https://github.com/TypeStrong/ts-node/issues/1007#issuecomment-689860997

The `--es-module-specifier-resolution` flag was introduced [in Node 12](https://medium.com/@nodejs/announcing-a-new-experimental-modules-1be8d2d6c2ff). With the release of Node 13, the flag was renamed to `--experimental-specifier-resolution`, with `--es-module-specifier-resolution` [acting as an alias to the new name](https://github.com/nodejs/node/issues/30520#issuecomment-588288220).

This fix aliases the `--es-module-specifier-resolution` flag in older versions of node, so that module resolution acts as expected. I also changed what seems to be a dead branch in the `esm-usage-example` directory.

I tested this with node 12, 13, and 14 and all seems to be working as expected.