### PR TITLE
Rewrite `transformers` doc to clarify factory - transpileOnly incompatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ _The name of the environment variable and the option's default value are denoted
 
 ### Programmatic-only Options
 
-* `transformers` `_ts.CustomTransformers | ((p: _ts.Program) => _ts.CustomTransformers)`: An object with transformers or a function that accepts a program and returns an transformers object to pass to TypeScript. Function isn't available with `transpileOnly` flag
+* `transformers` `_ts.CustomTransformers | ((p: _ts.Program) => _ts.CustomTransformers)`: An object with transformers or a factory function that accepts a program and returns a transformers object to pass to TypeScript. Factory function cannot be used with `transpileOnly` flag
 * `readFile`: Custom TypeScript-compatible file reading function
 * `fileExists`: Custom TypeScript-compatible file existence function
 


### PR DESCRIPTION
Reword to make it clearer that factory function cannot be used with transpileOnly, but object is still allowed