### PR TITLE
Test against node 15

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -100,16 +100,19 @@ jobs:
             nodeFlag: 15
             typescript: latest
             typescriptFlag: latest
+            downgradeNpm: true
           - flavor: 11
             node: 15
             nodeFlag: 15
             typescript: 2.7
             typescriptFlag: 2_7
+            downgradeNpm: true
           - flavor: 12
             node: 15
             nodeFlag: 15
             typescript: next
             typescriptFlag: next
+            downgradeNpm: true
     steps:
       # checkout code
       - uses: actions/checkout@v2
@@ -120,7 +123,8 @@ jobs:
           node-version: ${{ matrix.node }}
       # lint, build, test
         # Downgrade from npm 7 to 6 because 7 still seems buggy to me
-      - run: npmVersion="$(npm --version)" && [[ "${npmVersion:0:2}" = '7.' ]] && npm install -g npm@6
+      - if: ${{ matrix.downgradeNpm }}
+        run: npm install -g npm@6
       - run: npm install
       - run: npm run build-nopack
       - name: Download package artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -119,6 +119,8 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       # lint, build, test
+        # Downgrade from npm 7 to 6 because 7 still seems buggy to me
+      - run: npmVersion="$(npm --version)" && [[ "${npmVersion:0:2}" = '7.' ]] && npm install -g npm@6
       - run: npm install
       - run: npm run build-nopack
       - name: Download package artifact

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -39,23 +39,30 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, windows]
-        flavor: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        # Don't forget to add all new flavors to this list!
+        flavor: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
         include:
+          # Node 10
           - flavor: 1
             node: 10
             nodeFlag: 10
             typescript: latest
             typescriptFlag: latest
+          # Node 12.15
           - flavor: 2
             node: 12.15
             nodeFlag: 12_15
             typescript: latest
             typescriptFlag: latest
+          # Node 12.16
+          # TODO Add comments about why we test 2.15 and 2.16; I think git blame says it's because of an ESM behavioral change that happened at this version number
+          # TODO switch to '12' to get latest patch?
           - flavor: 3
             node: 12.16
             nodeFlag: 12_16
             typescript: latest
             typescriptFlag: latest
+          # Node 13
           - flavor: 4
             node: 13
             nodeFlag: 13
@@ -71,6 +78,7 @@ jobs:
             nodeFlag: 13
             typescript: next
             typescriptFlag: next
+          # Node 14
           - flavor: 7
             node: 14
             nodeFlag: 14
@@ -84,6 +92,22 @@ jobs:
           - flavor: 9
             node: 14
             nodeFlag: 14
+            typescript: next
+            typescriptFlag: next
+          # Node 15
+          - flavor: 10
+            node: 15
+            nodeFlag: 15
+            typescript: latest
+            typescriptFlag: latest
+          - flavor: 11
+            node: 15
+            nodeFlag: 15
+            typescript: 2.7
+            typescriptFlag: 2_7
+          - flavor: 12
+            node: 15
+            nodeFlag: 15
             typescript: next
             typescriptFlag: next
     steps:

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -106,6 +106,8 @@ describe('ts-node', function () {
     it('shows version of compiler via -vv', function (done) {
       exec(`${cmdNoProject} -vv`, function (err, stdout) {
         expect(err).to.equal(null)
+        console.dir(testsDirRequire.resolve('typescript/package'))
+        console.dir(testsDirRequire('typescript/package'))
         expect(stdout.trim()).to.equal(
           `ts-node v${ testsDirRequire('ts-node/package').version }\n` +
           `node ${ process.version }\n` +
@@ -282,6 +284,31 @@ describe('ts-node', function () {
 
         return done()
       })
+    })
+
+    it('sourcemaps should update when file is modified on disk, require.cache is cleaned, and file is recompiled', function (done) {
+      // Make temp directory
+      // Put file there
+      // require file
+      // clean require cache
+      // modify file
+      // re-require file
+      // check that stack trace of thrown error is correct
+
+      // exec(`${cmd} tests/throw`, function (err) {
+      //   if (err === null) {
+      //     return done('Command was expected to fail, but it succeeded.')
+      //   }
+
+      //   expect(err.message).to.contain([
+      //     `${join(__dirname, '../tests/throw.ts')}:100`,
+      //     '  bar () { throw new Error(\'this is a demo\') }',
+      //     '                 ^',
+      //     'Error: this is a demo'
+      //   ].join('\n'))
+
+      //   return done()
+      // })
     })
 
     it('should support transpile only mode', function (done) {
@@ -926,7 +953,7 @@ describe('ts-node', function () {
         }, function (err, stdout, stderr) {
           expect(err).to.not.equal(null)
           // expect error from node's default resolver
-          expect(stderr).to.match(/Error \[ERR_UNSUPPORTED_ESM_URL_SCHEME\]:.*\n *at defaultResolve/)
+          expect(stderr).to.match(/Error \[ERR_UNSUPPORTED_ESM_URL_SCHEME\]:.*(?:\n.*){0,1}\n *at defaultResolve/)
           return done()
         })
       })

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -106,8 +106,6 @@ describe('ts-node', function () {
     it('shows version of compiler via -vv', function (done) {
       exec(`${cmdNoProject} -vv`, function (err, stdout) {
         expect(err).to.equal(null)
-        console.dir(testsDirRequire.resolve('typescript/package'))
-        console.dir(testsDirRequire('typescript/package'))
         expect(stdout.trim()).to.equal(
           `ts-node v${ testsDirRequire('ts-node/package').version }\n` +
           `node ${ process.version }\n` +

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -286,31 +286,6 @@ describe('ts-node', function () {
       })
     })
 
-    it('sourcemaps should update when file is modified on disk, require.cache is cleaned, and file is recompiled', function (done) {
-      // Make temp directory
-      // Put file there
-      // require file
-      // clean require cache
-      // modify file
-      // re-require file
-      // check that stack trace of thrown error is correct
-
-      // exec(`${cmd} tests/throw`, function (err) {
-      //   if (err === null) {
-      //     return done('Command was expected to fail, but it succeeded.')
-      //   }
-
-      //   expect(err.message).to.contain([
-      //     `${join(__dirname, '../tests/throw.ts')}:100`,
-      //     '  bar () { throw new Error(\'this is a demo\') }',
-      //     '                 ^',
-      //     'Error: this is a demo'
-      //   ].join('\n'))
-
-      //   return done()
-      // })
-    })
-
     it('should support transpile only mode', function (done) {
       exec(`${cmd} --transpile-only -pe "x"`, function (err) {
         if (err === null) {


### PR DESCRIPTION
Add 3x new test matrix entries for node 15, against typescript 2.7, latest, and next

Fixed one test case, where we used a regexp to match an error stack from node.  Internal node changes meant the stack is slightly different, so I updated the regexp to match.

node 15 comes with npm v7, but npm v7 has some buggy(?) changes to peerDependencies handling.  I don't want to deal with this, so I avoid it by downgrading to npm v6.