### PR TITLE
allow typeCheck CLI flag to override transpileOnly tsconfig flag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -447,7 +447,8 @@ export function create (rawOptions: CreateOptions = {}): Register {
 
   const readFile = options.readFile || ts.sys.readFile
   const fileExists = options.fileExists || ts.sys.fileExists
-  const transpileOnly = options.transpileOnly === true || options.typeCheck === false
+  // typeCheck can override transpileOnly, useful for CLI flag to override config file
+  const transpileOnly = options.transpileOnly === true && options.typeCheck !== true
   const transformers = options.transformers || undefined
   const ignoreDiagnostics = [
     6059, // "'rootDir' is expected to contain all source files."


### PR DESCRIPTION
Fixes #1119

In #1119 we discussed some more ideal solutions, but this fix is simple and unblocks the user.