### PR TITLE
Tweak a comment that always confuses me

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,7 @@ export const DEFAULTS: RegisterOptions = {
 }
 
 /**
- * Default TypeScript compiler options required by `ts-node`.
+ * TypeScript compiler option overrides required by `ts-node`, which cannot be overridden.
  */
 const TS_NODE_COMPILER_OPTIONS = {
   sourceMap: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,7 @@ export const DEFAULTS: RegisterOptions = {
 }
 
 /**
- * TypeScript compiler option overrides required by `ts-node`, which cannot be overridden.
+ * TypeScript compiler option values required by `ts-node` which cannot be overridden.
  */
 const TS_NODE_COMPILER_OPTIONS = {
   sourceMap: true,


### PR DESCRIPTION
The comment used to say "default" which, at least to me, always implies that the options can be overridden.  Instead, these option values are necessary for ts-node to function, so they cannot be overridden by anything else.