### PR TITLE
Add nested package.json resolution to esm resolver

### DIFF
--- a/raw/node-esm-resolve-implementation.js
+++ b/raw/node-esm-resolve-implementation.js
@@ -231,7 +231,12 @@ function resolveExtensions(search) {
 }
 
 function resolveIndex(search) {
-  return resolveExtensions(new URL('index', search));
+  const index = resolveExtensions(new URL('index', search));
+  if (index !== undefined) return index;
+
+  const pkg = resolveExtensions(new URL('package', search));
+  const config = getPackageConfig(pkg, search);
+  return packageMainResolve(pkg, config, search);
 }
 
 function finalizeResolution(resolved, base) {


### PR DESCRIPTION
This PR adds an additional resolution strategy when resolving the `index` file if instead an `package.json` file is used to redirect to a `main` or `module` entry.

This is needed when you want to import e. g. `fp-ts` which defines for each module a `lib` (commonjs) and `es6` (esm) file and uses a `package.json` that only contains a `main` and `module` definition.