### PR TITLE
Rename `Register` to `Service`; re-export as `Register` for backwards…

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -9,7 +9,7 @@ import { diffLines } from 'diff'
 import { Script } from 'vm'
 import { readFileSync, statSync, realpathSync } from 'fs'
 import { homedir } from 'os'
-import { VERSION, TSError, parse, Register, register } from './index'
+import { VERSION, TSError, parse, Service, register } from './index'
 
 /**
  * Eval filename for REPL/debug.
@@ -284,7 +284,7 @@ function getCwd (dir?: string, scriptMode?: boolean, scriptPath?: string) {
 /**
  * Evaluate a script.
  */
-function evalAndExit (service: Register, state: EvalState, module: Module, code: string, isPrinted: boolean) {
+function evalAndExit (service: Service, state: EvalState, module: Module, code: string, isPrinted: boolean) {
   let result: any
 
   ;(global as any).__filename = module.filename
@@ -312,7 +312,7 @@ function evalAndExit (service: Register, state: EvalState, module: Module, code:
 /**
  * Evaluate the code snippet.
  */
-function _eval (service: Register, state: EvalState, input: string) {
+function _eval (service: Service, state: EvalState, input: string) {
   const lines = state.lines
   const isCompletion = !/\n$/.test(input)
   const undo = appendEval(state, input)
@@ -351,7 +351,7 @@ function exec (code: string, filename: string) {
 /**
  * Start a CLI REPL.
  */
-function startRepl (service: Register, state: EvalState, code?: string) {
+function startRepl (service: Service, state: EvalState, code?: string) {
   // Eval incoming code before the REPL starts.
   if (code) {
     try {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -643,7 +643,7 @@ describe('ts-node', function () {
   })
 
   describe('register', function () {
-    let registered: tsNodeTypes.Register
+    let registered: tsNodeTypes.Service
     let moduleTestPath: string
     before(() => {
       registered = register({
@@ -796,7 +796,7 @@ describe('ts-node', function () {
   })
 
   describe('create', () => {
-    let service: tsNodeTypes.Register
+    let service: tsNodeTypes.Service
     before(() => {
       service = create({ compilerOptions: { target: 'es5' }, skipProject: true })
     })
@@ -823,7 +823,7 @@ describe('ts-node', function () {
   })
 
   describe('issue #1098', () => {
-    function testIgnored (ignored: tsNodeTypes.Register['ignored'], allowed: string[], disallowed: string[]) {
+    function testIgnored (ignored: tsNodeTypes.Service['ignored'], allowed: string[], disallowed: string[]) {
       for (const ext of allowed) {
         expect(ignored(join(__dirname, `index${ext}`))).equal(false, `should accept ${ext} files`)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1031,15 +1031,15 @@ function registerExtensions (
  */
 function registerExtension (
   ext: string,
-  register: Service,
+  service: Service,
   originalHandler: (m: NodeModule, filename: string) => any
 ) {
   const old = require.extensions[ext] || originalHandler // tslint:disable-line
 
   require.extensions[ext] = function (m: any, filename) { // tslint:disable-line
-    if (register.ignored(filename)) return old(m, filename)
+    if (service.ignored(filename)) return old(m, filename)
 
-    if (register.options.experimentalEsmLoader) {
+    if (service.options.experimentalEsmLoader) {
       assertScriptCanLoadAsCJS(filename)
     }
 
@@ -1048,7 +1048,7 @@ function registerExtension (
     m._compile = function (code: string, fileName: string) {
       debug('module._compile', fileName)
 
-      return _compile.call(this, register.compile(code, fileName), fileName)
+      return _compile.call(this, service.compile(code, fileName), fileName)
     }
 
     return old(m, filename)


### PR DESCRIPTION
Based on conversation here: https://github.com/TypeStrong/ts-node/pull/1121#discussion_r528259816

`create()` will create a `Service`.  `register()` will create and register it into the node runtime.  But the object itself is not really a `Register` (noun), it's a `Service` which handles compilation.

Other names could be `Compiler`, `TsNodeCompiler`, or `Compiler`?