### PR TITLE
Fix misleading codecov failures

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,3 +2,14 @@ fixes:
   # Remap from npm-installed ts-node to root of project
   # This can take the place of ./scripts/rewrite-coverage-paths.js
   - "tests/node_modules/ts-node/::"
+
+coverage:
+  status:
+    patch:
+      default:
+        # Do not fail when `patch` coverage is low.  When this fails, it is misleading and not necessarily bad.
+        # For example if a patch changes 2 lines, and only one is covered, then patch coverage is 50%.
+        target: 0%
+    project:
+      default:
+        threshold: 1%


### PR DESCRIPTION
Tweaks codecov configuration.

Project coverage is allowed to fall up to 1% and will still get the green checkmark.

Patch coverage has no requirements and will always succeed.  I didn't feel like automatically-failing patch coverage was particularly useful.  For example, if a patch changes 2 lines, and only one is covered, then patch coverage is 50%.  This is IMO not necessarily a bad thing.