### PR TITLE
Fix: Keep search in resolveReplacementExtensions

### DIFF
--- a/dist-raw/node-esm-resolve-implementation.js
+++ b/dist-raw/node-esm-resolve-implementation.js
@@ -307,7 +307,8 @@ function resolveReplacementExtensions(search) {
     const pathnameWithoutExtension = search.pathname.slice(0, search.pathname.length - 3);
     for (let i = 0; i < replacementExtensions.length; i++) {
       const extension = replacementExtensions[i];
-      const guess = new URL(`${pathnameWithoutExtension}${extension}`, search);
+      const guess = new URL(search.toString());
+      guess.pathname = `${pathnameWithoutExtension}${extension}`;
       if (fileExists(guess)) return guess;
     }
   }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -932,6 +932,15 @@ describe('ts-node', function () {
         })
       })
 
+      it('should bypass import cache when changing search params', (done) => {
+        exec(`${cmd} index.ts`, { cwd: join(__dirname, '../tests/esm-import-cache') }, function (err, stdout) {
+          expect(err).to.equal(null)
+          expect(stdout).to.equal('log1\nlog2\nlog2\n')
+
+          return done()
+        })
+      })
+
       it('should support transpile only mode via dedicated loader entrypoint', (done) => {
         exec(`${cmd}/transpile-only index.ts`, { cwd: join(__dirname, '../tests/esm-transpile-only') }, function (err, stdout) {
           expect(err).to.equal(null)

--- a/tests/esm-import-cache/index.ts
+++ b/tests/esm-import-cache/index.ts
@@ -1,0 +1,4 @@
+import './log1.js'
+import './log1.js'
+import './log2.js'
+import './log2.js?bust'

--- a/tests/esm-import-cache/log1.ts
+++ b/tests/esm-import-cache/log1.ts
@@ -1,0 +1,1 @@
+console.log('log1')

--- a/tests/esm-import-cache/log2.ts
+++ b/tests/esm-import-cache/log2.ts
@@ -1,0 +1,1 @@
+console.log('log2')

--- a/tests/esm-import-cache/package.json
+++ b/tests/esm-import-cache/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/esm-import-cache/tsconfig.json
+++ b/tests/esm-import-cache/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "module": "ESNext",
+    "allowJs": true,
+    "moduleResolution": "node"
+  }
+}


### PR DESCRIPTION
Related to https://github.com/TypeStrong/ts-node/issues/1007#issuecomment-733894228

The search params were lost after making a partial copy to change the file extension.

Even though the `dist-raw` is largely a copy of Node's implementation, I believe this specific line is custom in `ts-node`.

@cspotcode Thanks for all the pointers you wrote in the comment!