### PR TITLE
Declare all env vars in an interface, to aid discoverability, make the code more self-documenting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,37 @@ declare global {
   }
 }
 
+/** @internal */
+export const env = process.env as ProcessEnv
+/**
+ * Declare all env vars, to aid discoverability.
+ * If an env var affects ts-node's behavior, it should not be buried somewhere in our codebase.
+ * @internal
+ */
+export interface ProcessEnv {
+  TS_NODE_DEBUG?: string
+  TS_NODE_DIR?: string
+  TS_NODE_EMIT?: string
+  TS_NODE_SCOPE?: string
+  TS_NODE_FILES?: string
+  TS_NODE_PRETTY?: string
+  TS_NODE_COMPILER?: string
+  TS_NODE_COMPILER_OPTIONS?: string
+  TS_NODE_IGNORE?: string
+  TS_NODE_PROJECT?: string
+  TS_NODE_SKIP_PROJECT?: string
+  TS_NODE_SKIP_IGNORE?: string
+  TS_NODE_PREFER_TS_EXTS?: string
+  TS_NODE_IGNORE_DIAGNOSTICS?: string
+  TS_NODE_TRANSPILE_ONLY?: string
+  TS_NODE_TYPE_CHECK?: string
+  TS_NODE_COMPILER_HOST?: string
+  TS_NODE_LOG_ERROR?: string
+  TS_NODE_HISTORY?: string
+
+  NODE_NO_READLINE?: string
+}
+
 /**
  * @internal
  */
@@ -63,7 +94,7 @@ function yn (value: string | undefined) {
 /**
  * Debugging `ts-node`.
  */
-const shouldDebug = yn(process.env.TS_NODE_DEBUG)
+const shouldDebug = yn(env.TS_NODE_DEBUG)
 /** @internal */
 export const debug = shouldDebug ?
   (...args: any) => console.log(`[ts-node ${new Date().toISOString()}]`, ...args)
@@ -284,23 +315,23 @@ export interface TypeInfo {
  * variables.
  */
 export const DEFAULTS: RegisterOptions = {
-  dir: process.env.TS_NODE_DIR,
-  emit: yn(process.env.TS_NODE_EMIT),
-  scope: yn(process.env.TS_NODE_SCOPE),
-  files: yn(process.env.TS_NODE_FILES),
-  pretty: yn(process.env.TS_NODE_PRETTY),
-  compiler: process.env.TS_NODE_COMPILER,
-  compilerOptions: parse(process.env.TS_NODE_COMPILER_OPTIONS),
-  ignore: split(process.env.TS_NODE_IGNORE),
-  project: process.env.TS_NODE_PROJECT,
-  skipProject: yn(process.env.TS_NODE_SKIP_PROJECT),
-  skipIgnore: yn(process.env.TS_NODE_SKIP_IGNORE),
-  preferTsExts: yn(process.env.TS_NODE_PREFER_TS_EXTS),
-  ignoreDiagnostics: split(process.env.TS_NODE_IGNORE_DIAGNOSTICS),
-  transpileOnly: yn(process.env.TS_NODE_TRANSPILE_ONLY),
-  typeCheck: yn(process.env.TS_NODE_TYPE_CHECK),
-  compilerHost: yn(process.env.TS_NODE_COMPILER_HOST),
-  logError: yn(process.env.TS_NODE_LOG_ERROR),
+  dir: env.TS_NODE_DIR,
+  emit: yn(env.TS_NODE_EMIT),
+  scope: yn(env.TS_NODE_SCOPE),
+  files: yn(env.TS_NODE_FILES),
+  pretty: yn(env.TS_NODE_PRETTY),
+  compiler: env.TS_NODE_COMPILER,
+  compilerOptions: parse(env.TS_NODE_COMPILER_OPTIONS),
+  ignore: split(env.TS_NODE_IGNORE),
+  project: env.TS_NODE_PROJECT,
+  skipProject: yn(env.TS_NODE_SKIP_PROJECT),
+  skipIgnore: yn(env.TS_NODE_SKIP_IGNORE),
+  preferTsExts: yn(env.TS_NODE_PREFER_TS_EXTS),
+  ignoreDiagnostics: split(env.TS_NODE_IGNORE_DIAGNOSTICS),
+  transpileOnly: yn(env.TS_NODE_TRANSPILE_ONLY),
+  typeCheck: yn(env.TS_NODE_TYPE_CHECK),
+  compilerHost: yn(env.TS_NODE_COMPILER_HOST),
+  logError: yn(env.TS_NODE_LOG_ERROR),
   experimentalEsmLoader: false
 }
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -3,7 +3,7 @@ import { homedir } from 'os'
 import { join } from 'path'
 import { Recoverable, start } from 'repl'
 import { Script } from 'vm'
-import { Service, CreateOptions, TSError } from './index'
+import { Service, CreateOptions, TSError, env } from './index'
 import { readFileSync, statSync } from 'fs'
 import { Console } from 'console'
 import * as tty from 'tty'
@@ -215,7 +215,7 @@ function startRepl (replService: ReplService, service: Service, state: EvalState
     input: replService.stdin,
     output: replService.stdout,
     // Mimicking node's REPL implementation: https://github.com/nodejs/node/blob/168b22ba073ee1cbf8d0bcb4ded7ff3099335d04/lib/internal/repl.js#L28-L30
-    terminal: (replService.stdout as tty.WriteStream).isTTY && !parseInt(process.env.NODE_NO_READLINE!, 10),
+    terminal: (replService.stdout as tty.WriteStream).isTTY && !parseInt(env.NODE_NO_READLINE!, 10),
     eval: replService.nodeEval,
     useGlobal: true
   })
@@ -254,7 +254,7 @@ function startRepl (replService: ReplService, service: Service, state: EvalState
 
   // Set up REPL history when available natively via node.js >= 11.
   if (repl.setupHistory) {
-    const historyPath = process.env.TS_NODE_HISTORY || join(homedir(), '.ts_node_repl_history')
+    const historyPath = env.TS_NODE_HISTORY || join(homedir(), '.ts_node_repl_history')
 
     repl.setupHistory(historyPath, err => {
       if (!err) return


### PR DESCRIPTION
This change declares all env vars we use in an interface, then accesses env vars via that interface.  So it's easier to see at a glance all env vars that affect ts-node.

Some context from Discord discussion:
https://discord.com/channels/508357248330760243/508357707602853888/800221938575867919

> [11:36 PM] cspotcode: should libraries (as opposed to CLI tools) be affected by environment variables?
With CLI tools, it seems clearer to me. Many support a collection of env vars to alter their behavior.
But I'm not so sure about libraries, since they're consumed within other tools
[11:51 PM] Gerrit0: I'd say no. I'm not a fan of env vars for CLI programs even... it's fine until someone sets up a script somewhere to set up "common environment variables"... and then if you don't run that script everything breaks.
[11:56 PM] Gerrit0: Discoverability for env vars is also really bad - they are global variables can be set by another program. I learned about OSG_FILE_PATH recently, which is a magical way of telling OpenSceneGraph where to load DLLs from... I've maintained this app for nearly a year and only just learned about it.