### PR TITLE
More accurate GH language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+raw/* linguist-vendored


### PR DESCRIPTION
Per https://github.com/github/linguist#overrides
Github language stats can be told about vendored code that is not actually part of your codebase, to make language stats more meaningful.

In our case, the `raw/` directory contains reference copies of files from node's source code that we didn't write nor do we distribute.