### PR TITLE
Remove tslint, add prettier, add semicolons

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,9 +3,14 @@
 root = true
 
 [*]
+# This also tells github.com how wide to render tabs
 indent_size = 2
 indent_style = space
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[{package.json,*.yml,dist-raw/**}]
+# In case we switch to tabs above, these must still be spaces
+indent_style = space

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+/*
+!/*.js
+!/*.mjs
+!/esm
+!/register
+!/scripts
+!/src
+!/tests
+tests/main-realpath/symlink/tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1937,6 +1937,12 @@
         }
       }
     },
+    "prettier": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
+      "dev": true
+    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "tsconfig.schemastore-schema.json"
   ],
   "scripts": {
-    "lint": "tslint \"src/**/*.ts\" --project tsconfig.json",
-    "lint-fix": "tslint \"src/**/*.ts\" --project tsconfig.json --fix",
+    "lint": "prettier --check .",
+    "lint-fix": "prettier --write .",
     "clean": "rimraf dist && rimraf tsconfig.schema.json && rimraf tsconfig.schemastore-schema.json && rimraf tests/ts-node-packed.tgz",
     "build": "npm run build-nopack && npm run build-pack",
     "build-nopack": "npm run clean && npm run build-tsc && npm run build-configSchema",
@@ -107,12 +107,11 @@
     "mocha": "^6.2.3",
     "ntypescript": "^1.201507091536.1",
     "nyc": "^15.0.1",
+    "prettier": "^2.2.1",
     "proxyquire": "^2.0.0",
     "react": "^16.14.0",
     "rimraf": "^3.0.0",
     "semver": "^7.1.3",
-    "tslint": "^6.1.0",
-    "tslint-config-standard": "^9.0.0",
     "typedoc": "^0.20.20",
     "typescript": "4.1.2",
     "typescript-json-schema": "^0.42.0",
@@ -128,5 +127,8 @@
     "make-error": "^1.1.1",
     "source-map-support": "^0.5.17",
     "yn": "3.1.1"
+  },
+  "prettier": {
+    "singleQuote": true
   }
 }


### PR DESCRIPTION
Fixes #1211 

As best I can tell, using tabs is the better choice for accessibility, so it's not an opinion or style choice.

Using semicolons is prettier's default.

Editorconfig will tell github to render tabs as 2 spaces, so code in the GH UI will still look the same.

Disabled tabs in dist-raw since that stuff should match whatever nodejs/node is doing.

## TODO

* [ ] remove old `// tslint:disable` comments