### PR TITLE
Fix #1229 and #1235: [BREAKING] always throw ERR_REQUIRE_ESM when attempting to execute ESM as CJS, even when ESM loader is not loaded

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -838,6 +838,12 @@ describe('ts-node', function () {
         expect(stderr).to.contain('Error [ERR_REQUIRE_ESM]: Must use import to load ES Module:')
       })
 
+      it('throws ERR_REQUIRE_ESM when attempting to require() an ESM script even when while ESM loader is not enabled', async () => {
+        const { err, stdout, stderr } = await exec(`${BIN_PATH} ./index.js`, { cwd: join(TEST_DIR, './esm-err-require-esm') })
+        expect(err).to.not.equal(null)
+        expect(stderr).to.contain('Error [ERR_REQUIRE_ESM]: Must use import to load ES Module:')
+      })
+
       it('defers to fallback loaders when URL should not be handled by ts-node', async () => {
         const { err, stdout, stderr } = await exec(`${cmd} index.mjs`, {
           cwd: join(TEST_DIR, './esm-import-http-url')
@@ -870,11 +876,5 @@ describe('ts-node', function () {
         expect(stdout).to.equal('')
       })
     }
-
-    it('executes ESM as CJS, ignoring package.json "types" field (for backwards compatibility; should be changed in next major release to throw ERR_REQUIRE_ESM)', async () => {
-      const { err, stdout } = await exec(`${BIN_PATH} ./esm-err-require-esm/index.js`)
-      expect(err).to.equal(null)
-      expect(stdout).to.equal('CommonJS\n')
-    })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1114,9 +1114,7 @@ function registerExtension (
   require.extensions[ext] = function (m: any, filename) { // tslint:disable-line
     if (service.ignored(filename)) return old(m, filename)
 
-    if (service.options.experimentalEsmLoader) {
-      assertScriptCanLoadAsCJS(filename)
-    }
+    assertScriptCanLoadAsCJS(filename)
 
     const _compile = m._compile
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,18 +19,16 @@ export { createRepl, CreateReplOptions, ReplService } from './repl'
  */
 const engineSupportsPackageTypeField = parseInt(process.versions.node.split('.')[0], 10) >= 12
 
-// Loaded conditionally so we don't need to support older node versions
-let assertScriptCanLoadAsCJSImpl: ((filename: string) => void) | undefined
-
 /**
  * Assert that script can be loaded as CommonJS when we attempt to require it.
  * If it should be loaded as ESM, throw ERR_REQUIRE_ESM like node does.
+ *
+ * Loaded conditionally so we don't need to support older node versions
  */
-function assertScriptCanLoadAsCJS (filename: string) {
-  if (!engineSupportsPackageTypeField) return
-  if (!assertScriptCanLoadAsCJSImpl) assertScriptCanLoadAsCJSImpl = require('../dist-raw/node-cjs-loader-utils').assertScriptCanLoadAsCJSImpl
-  assertScriptCanLoadAsCJSImpl!(filename)
-}
+const assertScriptCanLoadAsCJS: (filename: string) => void =
+  engineSupportsPackageTypeField
+  ? require('../dist-raw/node-cjs-loader-utils').assertScriptCanLoadAsCJSImpl
+  : () => {/* noop */}
 
 /**
  * Registered `ts-node` instance information.

--- a/src/testlib.ts
+++ b/src/testlib.ts
@@ -142,7 +142,7 @@ function createTestInterface<Context> (opts: {
   test.macro = function<Args extends any[]>(cb: (...args: Args) => [(title: string | undefined) => string, (t: ExecutionContext<Context>) => Promise<void>] | ((t: ExecutionContext<Context>) => Promise<void>)) {
     function macro (testInterface: ExecutionContext<Context>, ...args: Args) {
       const ret = cb(...args)
-      const [, macroFunction] = Array.isArray(ret) ? ret : [, ret]
+      const macroFunction = Array.isArray(ret) ? ret[1] : ret
       return macroFunction(testInterface)
     }
     macro.title = function (givenTitle: string | undefined, ...args: Args) {


### PR DESCRIPTION
Fix #1229 
Also fixes #1235

always throw ERR_REQUIRE_ESM when attempting to execute ESM as CJS, even when ESM loader is not loaded