### PR TITLE
#1202 supplemental: add --no-implicit-compiler-options which disables loading of implicit @tsconfig/bases

### DIFF
--- a/node10/tsconfig.json
+++ b/node10/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/node10"
+}

--- a/node10/tsconfig.json
+++ b/node10/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "extends": "@tsconfig/node10"
+  "extends": "@tsconfig/node10/tsconfig.json"
 }

--- a/node12/tsconfig.json
+++ b/node12/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/node12/tsconfig.json",
+}

--- a/node14/tsconfig.json
+++ b/node14/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/node14/tsconfig.json"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -394,6 +394,21 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tsconfig/node10": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.7.tgz",
+      "integrity": "sha512-aBvUmXLQbayM4w3A8TrjwrXs4DZ8iduJnuJLLRGdkWlyakCf1q6uHZJBzXoRA/huAEknG5tcUyQxN3A+In5euQ=="
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.7.tgz",
+      "integrity": "sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A=="
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.0.tgz",
+      "integrity": "sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ=="
+    },
     "@types/chai": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "./esm": "./esm.mjs",
     "./esm.mjs": "./esm.mjs",
     "./esm/transpile-only": "./esm/transpile-only.mjs",
-    "./esm/transpile-only.mjs": "./esm/transpile-only.mjs"
+    "./esm/transpile-only.mjs": "./esm/transpile-only.mjs",
+    "./node10/tsconfig.json": "./node10/tsconfig.json",
+    "./node12/tsconfig.json": "./node12/tsconfig.json",
+    "./node14/tsconfig.json": "./node14/tsconfig.json"
   },
   "types": "dist/index.d.ts",
   "bin": {
@@ -40,7 +43,10 @@
     "esm.mjs",
     "LICENSE",
     "tsconfig.schema.json",
-    "tsconfig.schemastore-schema.json"
+    "tsconfig.schemastore-schema.json",
+    "node10/",
+    "node12/",
+    "node14/"
   ],
   "scripts": {
     "lint": "tslint \"src/**/*.ts\" --project tsconfig.json",
@@ -131,6 +137,9 @@
     "typescript": ">=2.7"
   },
   "dependencies": {
+    "@tsconfig/node10": "^1.0.7",
+    "@tsconfig/node12": "^1.0.7",
+    "@tsconfig/node14": "^1.0.0",
     "arg": "^4.1.0",
     "create-require": "^1.1.0",
     "diff": "^4.0.1",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -45,6 +45,7 @@ export function main (argv: string[] = process.argv.slice(2), entrypointArgs: Re
       '--compiler-host': Boolean,
       '--pretty': Boolean,
       '--skip-project': Boolean,
+      '--no-implicit-compiler-options': Boolean,
       '--skip-ignore': Boolean,
       '--prefer-ts-exts': Boolean,
       '--log-error': Boolean,
@@ -90,6 +91,7 @@ export function main (argv: string[] = process.argv.slice(2), entrypointArgs: Re
     '--files': files,
     '--compiler': compiler,
     '--compiler-options': compilerOptions,
+    '--no-implicit-compiler-options': noImplicitCompilerOptions,
     '--project': project,
     '--ignore-diagnostics': ignoreDiagnostics,
     '--ignore': ignore,
@@ -132,6 +134,7 @@ export function main (argv: string[] = process.argv.slice(2), entrypointArgs: Re
     --files                        Load \`files\`, \`include\` and \`exclude\` from \`tsconfig.json\` on startup
     --pretty                       Use pretty diagnostic formatter (usually enabled by default)
     --skip-project                 Skip reading \`tsconfig.json\`
+    --no-implicit-compiler-options Do not use a default \`tsconfig.json\` from @tsconfig/bases matching your node version.
     --skip-ignore                  Skip \`--ignore\` checks
     --prefer-ts-exts               Prefer importing TypeScript files over JavaScript files
     --log-error                    Logs TypeScript errors to stderr instead of throwing exceptions
@@ -172,6 +175,7 @@ export function main (argv: string[] = process.argv.slice(2), entrypointArgs: Re
     compiler,
     ignoreDiagnostics,
     compilerOptions,
+    noImplicitCompilerOptions,
     require: argsRequire,
     readFile: code !== undefined ? evalAwarePartialHost.readFile : undefined,
     fileExists: code !== undefined ? evalAwarePartialHost.fileExists : undefined

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -6,7 +6,7 @@ import semver = require('semver')
 import ts = require('typescript')
 import proxyquire = require('proxyquire')
 import type * as tsNodeTypes from './index'
-import { unlinkSync, existsSync, lstatSync } from 'fs'
+import { unlinkSync, existsSync, lstatSync, mkdtempSync, fstat, copyFileSync } from 'fs'
 import * as promisify from 'util.promisify'
 import { sync as rimrafSync } from 'rimraf'
 import type _createRequire from 'create-require'
@@ -535,6 +535,15 @@ test.suite('ts-node', (test) => {
         expect(options.transpileOnly).to.equal(true)
         expect(options.require).to.deep.equal([join(TEST_DIR, './tsconfig-options/required1.js')])
       })
+    })
+
+    test('should use implicit @tsconfig/bases config when one is not loaded from disk', async (t) => {
+      const tempDir = mkdtempSync('ts-node-spec')
+      // const fixtureDir = join(TEST_DIR, 'implicit-tsconfig')
+      // copyFileSync(join(fixtureDir, 'script.ts'), join(tempDir, 'script.ts'))
+      const { err, stdout, stderr } = await exec(`${BIN_PATH} -pe 10n`, { cwd: tempDir })
+      expect(err).to.equal(null)
+      expect(stdout).to.equal('10n\n')
     })
 
     test.suite('compiler host', (test) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1233,7 +1233,7 @@ function readConfig (
     config.include = []
   }
 
-  const skipDefaultCompilerOptions = rawApiOptions.skipDefaultCompilerOptions ?? DEFAULTS.skipDefaultCompilerOptions
+  const skipDefaultCompilerOptions = rawApiOptions.skipDefaultCompilerOptions ?? DEFAULTS.skipDefaultCompilerOptions ?? configFilePath != null // tslint:disable-line:strict-type-predicates
   const defaultCompilerOptionsForNodeVersion = skipDefaultCompilerOptions ? undefined : getDefaultTsconfigJsonForNodeVersion().compilerOptions
   // Override default configuration options `ts-node` requires.
   config.compilerOptions = Object.assign(

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,12 +265,14 @@ export interface CreateOptions {
    */
   skipProject?: boolean
   /**
-   * Skip loading a default @tsconfig/* that matches the version of nodejs
-   * TODO needs a better name
+   * Do not apply compiler options from the @tsconfig/bases configuration matching your node version
+   *
+   * This option has no effect if a tsconfig.json is loaded, because loading a tsconfig.json disables
+   * implicit compiler options.
    *
    * @default false
    */
-  skipDefaultCompilerOptions?: boolean
+  noImplicitCompilerOptions?: boolean
   /**
    * Skip ignore check, so that compilation will be attempted for all files with matching extensions.
    *
@@ -329,6 +331,7 @@ export interface TsConfigOptions extends Omit<RegisterOptions,
   | 'readFile'
   | 'fileExists'
   | 'skipProject'
+  | 'noImplicitCompilerOptions'
   | 'project'
   | 'dir'
   | 'cwd'
@@ -336,7 +339,6 @@ export interface TsConfigOptions extends Omit<RegisterOptions,
   | 'scope'
   | 'scopeDir'
   | 'experimentalEsmLoader'
-  | 'skipDefaultCompilerOptions'
   > {}
 
 /**
@@ -384,7 +386,7 @@ export const DEFAULTS: RegisterOptions = {
   compilerHost: yn(env.TS_NODE_COMPILER_HOST),
   logError: yn(env.TS_NODE_LOG_ERROR),
   experimentalEsmLoader: false,
-  skipDefaultCompilerOptions: false
+  noImplicitCompilerOptions: false
 }
 
 /**
@@ -1247,7 +1249,7 @@ function readConfig (
   }
 
   // Only if a config file is *not* loaded, load an implicit configuration from @tsconfig/bases
-  const skipDefaultCompilerOptions = configFilePath != null || (rawApiOptions.skipDefaultCompilerOptions ?? DEFAULTS.skipDefaultCompilerOptions) // tslint:disable-line
+  const skipDefaultCompilerOptions = configFilePath != null || (rawApiOptions.noImplicitCompilerOptions ?? DEFAULTS.noImplicitCompilerOptions) // tslint:disable-line
   const defaultCompilerOptionsForNodeVersion = skipDefaultCompilerOptions ? undefined : getDefaultTsconfigJsonForNodeVersion(ts).compilerOptions
 
   // Merge compilerOptions from all sources

--- a/src/index.ts
+++ b/src/index.ts
@@ -1233,8 +1233,9 @@ function readConfig (
     config.include = []
   }
 
-  const skipDefaultCompilerOptions = rawApiOptions.skipDefaultCompilerOptions ?? DEFAULTS.skipDefaultCompilerOptions ?? configFilePath != null // tslint:disable-line:strict-type-predicates
+  const skipDefaultCompilerOptions = configFilePath != null || (rawApiOptions.skipDefaultCompilerOptions ?? DEFAULTS.skipDefaultCompilerOptions)
   const defaultCompilerOptionsForNodeVersion = skipDefaultCompilerOptions ? undefined : getDefaultTsconfigJsonForNodeVersion().compilerOptions
+  console.error(util.inspect({ skipDefaultCompilerOptions, defaultCompilerOptionsForNodeVersion }))
   // Override default configuration options `ts-node` requires.
   config.compilerOptions = Object.assign(
     {},

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,7 @@ export interface TSCommon {
   parseJsonConfigFileContent: typeof _ts.parseJsonConfigFileContent
   formatDiagnostics: typeof _ts.formatDiagnostics
   formatDiagnosticsWithColorAndContext: typeof _ts.formatDiagnosticsWithColorAndContext
+  libs?: string[]
 }
 
 /**
@@ -1235,7 +1236,7 @@ function readConfig (
 
   // Only if a config file is *not* loaded, load an implicit configuration from @tsconfig/bases
   const skipDefaultCompilerOptions = configFilePath != null || (rawApiOptions.skipDefaultCompilerOptions ?? DEFAULTS.skipDefaultCompilerOptions) // tslint:disable-line
-  const defaultCompilerOptionsForNodeVersion = skipDefaultCompilerOptions ? undefined : getDefaultTsconfigJsonForNodeVersion().compilerOptions
+  const defaultCompilerOptionsForNodeVersion = skipDefaultCompilerOptions ? undefined : getDefaultTsconfigJsonForNodeVersion(ts).compilerOptions
 
   // Merge compilerOptions from all sources
   config.compilerOptions = Object.assign(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1233,18 +1233,25 @@ function readConfig (
     config.include = []
   }
 
-  const skipDefaultCompilerOptions = configFilePath != null || (rawApiOptions.skipDefaultCompilerOptions ?? DEFAULTS.skipDefaultCompilerOptions)
+  // Only if a config file is *not* loaded, load an implicit configuration from @tsconfig/bases
+  const skipDefaultCompilerOptions = configFilePath != null || (rawApiOptions.skipDefaultCompilerOptions ?? DEFAULTS.skipDefaultCompilerOptions) // tslint:disable-line
   const defaultCompilerOptionsForNodeVersion = skipDefaultCompilerOptions ? undefined : getDefaultTsconfigJsonForNodeVersion().compilerOptions
-  console.error(util.inspect({ skipDefaultCompilerOptions, defaultCompilerOptionsForNodeVersion }))
-  // Override default configuration options `ts-node` requires.
+
+  // Merge compilerOptions from all sources
   config.compilerOptions = Object.assign(
     {},
-    defaultCompilerOptionsForNodeVersion, // automatically-applied options from @tsconfig/bases
-    config.compilerOptions, // tsconfig.json "compilerOptions"
-    DEFAULTS.compilerOptions, // from env var
-    tsNodeOptionsFromTsconfig.compilerOptions, // tsconfig.json "ts-node": "compilerOptions"
-    rawApiOptions.compilerOptions, // passed programmatically
-    TS_NODE_COMPILER_OPTIONS // overrides required by ts-node, cannot be changed
+    // automatically-applied options from @tsconfig/bases
+    defaultCompilerOptionsForNodeVersion,
+    // tsconfig.json "compilerOptions"
+    config.compilerOptions,
+    // from env var
+    DEFAULTS.compilerOptions,
+    // tsconfig.json "ts-node": "compilerOptions"
+    tsNodeOptionsFromTsconfig.compilerOptions,
+    // passed programmatically
+    rawApiOptions.compilerOptions,
+    // overrides required by ts-node, cannot be changed
+    TS_NODE_COMPILER_OPTIONS
   )
 
   const fixedConfig = fixConfig(ts, ts.parseJsonConfigFileContent(config, {

--- a/src/tsconfigs.ts
+++ b/src/tsconfigs.ts
@@ -1,0 +1,12 @@
+import type * as _ts from "typescript";
+
+const nodeMajor = parseInt(process.versions.node.split('.')[0], 10)
+/**
+ * return parsed JSON of the bundled @tsconfig/bases config appropriate for the
+ * running version of nodejs
+ */
+export function getDefaultTsconfigJsonForNodeVersion(): any {
+  return nodeMajor >= 14 ? require('@tsconfig/node14/tsconfig.json') :
+    nodeMajor >= 12 ? require('@tsconfig/node12/tsconfig.json') :
+    require('@tsconfig/node10/tsconfig.json')
+}

--- a/src/tsconfigs.ts
+++ b/src/tsconfigs.ts
@@ -4,20 +4,21 @@ const nodeMajor = parseInt(process.versions.node.split('.')[0], 10)
 /**
  * return parsed JSON of the bundled @tsconfig/bases config appropriate for the
  * running version of nodejs
+ * @internal
  */
 export function getDefaultTsconfigJsonForNodeVersion (ts: TSCommon): any {
-  if(nodeMajor >= 14) {
+  if (nodeMajor >= 14) {
     const config = require('@tsconfig/node14/tsconfig.json')
-    if(configCompatible(config)) return config
+    if (configCompatible(config)) return config
   }
-  if(nodeMajor >= 12) {
+  if (nodeMajor >= 12) {
     const config = require('@tsconfig/node12/tsconfig.json')
-    if(configCompatible(config)) return config
+    if (configCompatible(config)) return config
   }
   return require('@tsconfig/node10/tsconfig.json')
 
   // Verify that tsconfig target and lib options are compatible with TypeScript compiler
-  function configCompatible(config: {
+  function configCompatible (config: {
     compilerOptions: {
       lib: string[],
       target: string

--- a/src/tsconfigs.ts
+++ b/src/tsconfigs.ts
@@ -1,11 +1,11 @@
-import type * as _ts from "typescript";
+import type * as _ts from 'typescript'
 
 const nodeMajor = parseInt(process.versions.node.split('.')[0], 10)
 /**
  * return parsed JSON of the bundled @tsconfig/bases config appropriate for the
  * running version of nodejs
  */
-export function getDefaultTsconfigJsonForNodeVersion(): any {
+export function getDefaultTsconfigJsonForNodeVersion (): any {
   return nodeMajor >= 14 ? require('@tsconfig/node14/tsconfig.json') :
     nodeMajor >= 12 ? require('@tsconfig/node12/tsconfig.json') :
     require('@tsconfig/node10/tsconfig.json')

--- a/src/tsconfigs.ts
+++ b/src/tsconfigs.ts
@@ -1,12 +1,32 @@
-import type * as _ts from 'typescript'
+import { TSCommon } from '.'
 
 const nodeMajor = parseInt(process.versions.node.split('.')[0], 10)
 /**
  * return parsed JSON of the bundled @tsconfig/bases config appropriate for the
  * running version of nodejs
  */
-export function getDefaultTsconfigJsonForNodeVersion (): any {
-  return nodeMajor >= 14 ? require('@tsconfig/node14/tsconfig.json') :
-    nodeMajor >= 12 ? require('@tsconfig/node12/tsconfig.json') :
-    require('@tsconfig/node10/tsconfig.json')
+export function getDefaultTsconfigJsonForNodeVersion (ts: TSCommon): any {
+  if(nodeMajor >= 14) {
+    const config = require('@tsconfig/node14/tsconfig.json')
+    if(configCompatible(config)) return config
+  }
+  if(nodeMajor >= 12) {
+    const config = require('@tsconfig/node12/tsconfig.json')
+    if(configCompatible(config)) return config
+  }
+  return require('@tsconfig/node10/tsconfig.json')
+
+  // Verify that tsconfig target and lib options are compatible with TypeScript compiler
+  function configCompatible(config: {
+    compilerOptions: {
+      lib: string[],
+      target: string
+    }
+  }) {
+    return (
+      typeof (ts.ScriptTarget as any)[config.compilerOptions.target.toUpperCase()] === 'number' &&
+      ts.libs &&
+      config.compilerOptions.lib.every(lib => ts.libs!.includes(lib))
+    )
+  }
 }


### PR DESCRIPTION
Supplement to #1202

Decided not to add this flag until it's requested.  Users can always write a tsconfig.json which should cover their needs, so this flag may never be needed.

The code is here in this branch in case we need to add it in the future.

This branch may not merge cleanly due to git history weirdness, but you should be able to generate a diff between this branch and the repo immediately after #1236 was merged.

Creating as closed to keep the PR queue clean.