### PR TITLE
recognize when //# sourceMappingURL is percent-encoded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1344,8 +1344,9 @@ function updateOutput(
       sourceMapContent
     );
   }
+  // If anyone asks why we're not using URL, the URL equivalent is: `u = new URL('http://d'); u.pathname = "/" + sourcemapFilename; return u.pathname.slice(1);
   const sourceMapLengthWithPercentEncoding =
-    prefixLength + urlFormat(sourcemapFilename).length;
+    prefixLength + encodeURI(sourcemapFilename).length;
   if (
     outputText.substr(-sourceMapLengthWithPercentEncoding, prefixLength) ===
     prefix

--- a/src/index.ts
+++ b/src/index.ts
@@ -1336,8 +1336,8 @@ function updateOutput(
    *     Not ideal, but appending our sourcemap *after* a pre-existing sourcemap still overrides, so the end-user is happy.
    */
   if (
-    outputText.substr(-sourceMapLengthWithoutPercentEncoding, prefixLength) ==
-    '//# sourceMappingURL='
+    outputText.substr(-sourceMapLengthWithoutPercentEncoding, prefixLength) ===
+    prefix
   ) {
     return (
       outputText.slice(0, -sourceMapLengthWithoutPercentEncoding) +
@@ -1348,7 +1348,7 @@ function updateOutput(
     prefixLength + urlFormat(sourcemapFilename).length;
   if (
     outputText.substr(-sourceMapLengthWithPercentEncoding, prefixLength) ===
-    '//# sourceMappingURL='
+    prefix
   ) {
     return (
       outputText.slice(0, -sourceMapLengthWithPercentEncoding) +

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { relative, basename, extname, resolve, dirname, join } from 'path';
 import { Module } from 'module';
 import * as util from 'util';
-import { fileURLToPath, format as urlFormat } from 'url';
+import { fileURLToPath } from 'url';
 
 import sourceMapSupport = require('source-map-support');
 import { BaseError } from 'make-error';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1325,23 +1325,38 @@ function updateOutput(
   const baseName = /*foo.tsx*/ basename(fileName);
   const extName = /*.tsx*/ extname(fileName);
   const extension = /*.js*/ getExtension(fileName);
-  const sourcemapFilename = baseName.slice(-extName.length) + extension + '.map';
-  const sourceMapLengthWithoutPercentEncoding = prefixLength + sourcemapFilename.length;
+  const sourcemapFilename =
+    baseName.slice(-extName.length) + extension + '.map';
+  const sourceMapLengthWithoutPercentEncoding =
+    prefixLength + sourcemapFilename.length;
   /*
    * Only rewrite if existing directive exists at the location we expect, to support:
    *   a) compilers that do not append a sourcemap directive
    *   b) situations where we did the math wrong
    *     Not ideal, but appending our sourcemap *after* a pre-existing sourcemap still overrides, so the end-user is happy.
    */
-  if(outputText.substr(-sourceMapLengthWithoutPercentEncoding, prefixLength) == '//# sourceMappingURL=') {
-    return outputText.slice(0, -sourceMapLengthWithoutPercentEncoding) + sourceMapContent;
+  if (
+    outputText.substr(-sourceMapLengthWithoutPercentEncoding, prefixLength) ==
+    '//# sourceMappingURL='
+  ) {
+    return (
+      outputText.slice(0, -sourceMapLengthWithoutPercentEncoding) +
+      sourceMapContent
+    );
   }
-  const sourceMapLengthWithPercentEncoding = prefixLength + urlFormat(sourcemapFilename).length;
-  if(outputText.substr(-sourceMapLengthWithPercentEncoding, prefixLength) === '//# sourceMappingURL=') {
-    return outputText.slice(0, -sourceMapLengthWithPercentEncoding) + sourceMapContent;
+  const sourceMapLengthWithPercentEncoding =
+    prefixLength + urlFormat(sourcemapFilename).length;
+  if (
+    outputText.substr(-sourceMapLengthWithPercentEncoding, prefixLength) ===
+    '//# sourceMappingURL='
+  ) {
+    return (
+      outputText.slice(0, -sourceMapLengthWithPercentEncoding) +
+      sourceMapContent
+    );
   }
 
-  return `${ outputText }\n${ sourceMapContent }`;
+  return `${outputText}\n${sourceMapContent}`;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1326,7 +1326,7 @@ function updateOutput(
   const extName = /*.tsx*/ extname(fileName);
   const extension = /*.js*/ getExtension(fileName);
   const sourcemapFilename =
-    baseName.slice(-extName.length) + extension + '.map';
+    baseName.slice(0, -extName.length) + extension + '.map';
   const sourceMapLengthWithoutPercentEncoding =
     prefixLength + sourcemapFilename.length;
   /*


### PR DESCRIPTION
TypeScript 4.1.1 started percent-encoding the filenames in `//# sourceMappingURL`

Before TS 4.1.1:
```
//# sourceMappingURL=foo bar.js.map
```

After TS 4.1.1
```
//# sourceMappingURL=foo%20bar.js.map
```

Changes made to support `--transpiler` (#1160) effectively avoided this issue.  We computed where we thought the comment should begin, but if it wasn't at that position, we simply appended our `sourceMappingURL` comment, overriding whatever was already there.  This means if a path was percent-encoded, we didn't care: we appended, overrode, and users were happy.

Nevertheless, this PR implements logic to percent-encode the path and check for a sourceMappingURL comment at that offset.

The new logic is:
- check based on non-percent-encoded path.  If found, replace the comment
- check based on percent-encoded path.  If found, replace the comment
- If neither found, append our `sourceMappingURL` comment after any comment that might already be there

See also: #1322