### PR TITLE
Detect esm builtins protocol change on node 12.20.0

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         os: [ubuntu, windows]
         # Don't forget to add all new flavors to this list!
-        flavor: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        flavor: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
         include:
           # Node 12.15
           # TODO Add comments about why we test 12.15; I think git blame says it's because of an ESM behavioral change that happened at 12.16
@@ -57,49 +57,56 @@ jobs:
             nodeFlag: 12_15
             typescript: latest
             typescriptFlag: latest
-          # Node 12
+          # Node 12.16
+          # Earliest version that supports getFormat, etc hooks: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.16.0
           - flavor: 2
+            node: 12.16
+            nodeFlag: 12_16
+            typescript: latest
+            typescriptFlag: latest
+          # Node 12
+          - flavor: 3
             node: 12
             nodeFlag: 12
             typescript: latest
             typescriptFlag: latest
           # Node 14.13.0
           # To test ESM builtin module resolution immediately before a node behavioral change: https://github.com/TypeStrong/ts-node/issues/1130
-          - flavor: 3
+          - flavor: 4
             node: 14.13.0
             nodeFlag: 14_13_0
             typescript: latest
             typescriptFlag: latest
           # Node 14
-          - flavor: 4
+          - flavor: 5
             node: 14
             nodeFlag: 14
             typescript: latest
             typescriptFlag: latest
-          - flavor: 5
+          - flavor: 6
             node: 14
             nodeFlag: 14
             typescript: 2.7
             typescriptFlag: 2_7
-          - flavor: 6
+          - flavor: 7
             node: 14
             nodeFlag: 14
             typescript: next
             typescriptFlag: next
           # Node 16
-          - flavor: 7
+          - flavor: 8
             node: 16
             nodeFlag: 16
             typescript: latest
             typescriptFlag: latest
             downgradeNpm: true
-          - flavor: 8
+          - flavor: 9
             node: 16
             nodeFlag: 16
             typescript: 2.7
             typescriptFlag: 2_7
             downgradeNpm: true
-          - flavor: 9
+          - flavor: 10
             node: 16
             nodeFlag: 16
             typescript: next

--- a/dist-raw/node-esm-resolve-implementation.js
+++ b/dist-raw/node-esm-resolve-implementation.js
@@ -5,11 +5,17 @@
 'use strict';
 
 const [nodeMajor, nodeMinor, nodePatch] = process.versions.node.split('.').map(s => parseInt(s, 10))
-// Test for 14.13.1 or higher
+// Test for node >14.13.1 || (>=12.20.0 && <13)
 const builtinModuleProtocol = nodeMajor > 14 || (
     nodeMajor === 14 && (
       nodeMinor > 13 || (
         nodeMinor === 13 && nodePatch > 0
+      )
+    )
+  ) || (
+    nodeMajor === 12 && (
+      nodeMinor > 20 || (
+        nodeMinor === 20
       )
     )
   )

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1195,10 +1195,10 @@ test.suite('ts-node', (test) => {
   });
 
   test.suite('esm', (test) => {
-    const experimentalModulesFlag = semver.gte(process.version, '12.17.0') ? '' : '--experimental-modules';
-    const cmd = `node ${
-      experimentalModulesFlag
-    } --loader ts-node/esm`;
+    const experimentalModulesFlag = semver.gte(process.version, '12.17.0')
+      ? ''
+      : '--experimental-modules';
+    const cmd = `node ${experimentalModulesFlag} --loader ts-node/esm`;
 
     if (semver.gte(process.version, '12.16.0')) {
       test('should compile and execute as ESM', async () => {
@@ -1253,7 +1253,7 @@ test.suite('ts-node', (test) => {
             cwd: join(TEST_DIR, './esm-node-resolver'),
             env: {
               ...process.env,
-              NODE_OPTIONS: `${ experimentalModulesFlag } --experimental-specifier-resolution=node`,
+              NODE_OPTIONS: `${experimentalModulesFlag} --experimental-specifier-resolution=node`,
             },
           });
           expect(err).to.equal(null);

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1195,9 +1195,10 @@ test.suite('ts-node', (test) => {
   });
 
   test.suite('esm', (test) => {
-    const cmd = `node --loader ts-node/esm${
-      semver.gte(process.version, '12.17.0') ? '' : ' --experimental-modules'
-    }`;
+    const experimentalModulesFlag = semver.gte(process.version, '12.17.0') ? '' : '--experimental-modules';
+    const cmd = `node ${
+      experimentalModulesFlag
+    } --loader ts-node/esm`;
 
     if (semver.gte(process.version, '12.16.0')) {
       test('should compile and execute as ESM', async () => {
@@ -1252,7 +1253,7 @@ test.suite('ts-node', (test) => {
             cwd: join(TEST_DIR, './esm-node-resolver'),
             env: {
               ...process.env,
-              NODE_OPTIONS: '--experimental-specifier-resolution=node',
+              NODE_OPTIONS: `${ experimentalModulesFlag } --experimental-specifier-resolution=node`,
             },
           });
           expect(err).to.equal(null);

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1195,7 +1195,7 @@ test.suite('ts-node', (test) => {
   });
 
   test.suite('esm', (test) => {
-    const cmd = `node --loader ts-node/esm`;
+    const cmd = `node --loader ts-node/esm${ semver.gte(process.version, '12.17.0') ? '' : ' --experimental-modules' }`;
 
     if (semver.gte(process.version, '12.16.0')) {
       test('should compile and execute as ESM', async () => {

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1195,7 +1195,9 @@ test.suite('ts-node', (test) => {
   });
 
   test.suite('esm', (test) => {
-    const cmd = `node --loader ts-node/esm${ semver.gte(process.version, '12.17.0') ? '' : ' --experimental-modules' }`;
+    const cmd = `node --loader ts-node/esm${
+      semver.gte(process.version, '12.17.0') ? '' : ' --experimental-modules'
+    }`;
 
     if (semver.gte(process.version, '12.16.0')) {
       test('should compile and execute as ESM', async () => {

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1197,123 +1197,125 @@ test.suite('ts-node', (test) => {
   test.suite('esm', (test) => {
     const cmd = `node --loader ts-node/esm`;
 
-    test('should compile and execute as ESM', async () => {
-      const { err, stdout } = await exec(`${cmd} index.ts`, {
-        cwd: join(TEST_DIR, './esm'),
-      });
-      expect(err).to.equal(null);
-      expect(stdout).to.equal('foo bar baz biff libfoo\n');
-    });
-    test('should use source maps', async () => {
-      const { err, stdout } = await exec(`${cmd} "throw error.ts"`, {
-        cwd: join(TEST_DIR, './esm'),
-      });
-      expect(err).not.to.equal(null);
-      expect(err!.message).to.contain(
-        [
-          `${pathToFileURL(join(TEST_DIR, './esm/throw error.ts'))
-            .toString()
-            .replace(/%20/g, ' ')}:100`,
-          "  bar() { throw new Error('this is a demo'); }",
-          '                ^',
-          'Error: this is a demo',
-        ].join('\n')
-      );
-    });
-
-    test.suite('supports experimental-specifier-resolution=node', (test) => {
-      test('via --experimental-specifier-resolution', async () => {
-        const {
-          err,
-          stdout,
-        } = await exec(
-          `${cmd} --experimental-specifier-resolution=node index.ts`,
-          { cwd: join(TEST_DIR, './esm-node-resolver') }
-        );
-        expect(err).to.equal(null);
-        expect(stdout).to.equal('foo bar baz biff libfoo\n');
-      });
-      test('via --es-module-specifier-resolution alias', async () => {
-        const {
-          err,
-          stdout,
-        } = await exec(
-          `${cmd} --experimental-modules --es-module-specifier-resolution=node index.ts`,
-          { cwd: join(TEST_DIR, './esm-node-resolver') }
-        );
-        expect(err).to.equal(null);
-        expect(stdout).to.equal('foo bar baz biff libfoo\n');
-      });
-      test('via NODE_OPTIONS', async () => {
+    if (semver.gte(process.version, '12.16.0')) {
+      test('should compile and execute as ESM', async () => {
         const { err, stdout } = await exec(`${cmd} index.ts`, {
-          cwd: join(TEST_DIR, './esm-node-resolver'),
-          env: {
-            ...process.env,
-            NODE_OPTIONS: '--experimental-specifier-resolution=node',
-          },
+          cwd: join(TEST_DIR, './esm'),
         });
         expect(err).to.equal(null);
         expect(stdout).to.equal('foo bar baz biff libfoo\n');
       });
-    });
-
-    test('throws ERR_REQUIRE_ESM when attempting to require() an ESM script when ESM loader is enabled', async () => {
-      const { err, stderr } = await exec(`${cmd} ./index.js`, {
-        cwd: join(TEST_DIR, './esm-err-require-esm'),
+      test('should use source maps', async () => {
+        const { err, stdout } = await exec(`${cmd} "throw error.ts"`, {
+          cwd: join(TEST_DIR, './esm'),
+        });
+        expect(err).not.to.equal(null);
+        expect(err!.message).to.contain(
+          [
+            `${pathToFileURL(join(TEST_DIR, './esm/throw error.ts'))
+              .toString()
+              .replace(/%20/g, ' ')}:100`,
+            "  bar() { throw new Error('this is a demo'); }",
+            '                ^',
+            'Error: this is a demo',
+          ].join('\n')
+        );
       });
-      expect(err).to.not.equal(null);
-      expect(stderr).to.contain(
-        'Error [ERR_REQUIRE_ESM]: Must use import to load ES Module:'
-      );
-    });
 
-    test('defers to fallback loaders when URL should not be handled by ts-node', async () => {
-      const { err, stdout, stderr } = await exec(`${cmd} index.mjs`, {
-        cwd: join(TEST_DIR, './esm-import-http-url'),
+      test.suite('supports experimental-specifier-resolution=node', (test) => {
+        test('via --experimental-specifier-resolution', async () => {
+          const {
+            err,
+            stdout,
+          } = await exec(
+            `${cmd} --experimental-specifier-resolution=node index.ts`,
+            { cwd: join(TEST_DIR, './esm-node-resolver') }
+          );
+          expect(err).to.equal(null);
+          expect(stdout).to.equal('foo bar baz biff libfoo\n');
+        });
+        test('via --es-module-specifier-resolution alias', async () => {
+          const {
+            err,
+            stdout,
+          } = await exec(
+            `${cmd} --experimental-modules --es-module-specifier-resolution=node index.ts`,
+            { cwd: join(TEST_DIR, './esm-node-resolver') }
+          );
+          expect(err).to.equal(null);
+          expect(stdout).to.equal('foo bar baz biff libfoo\n');
+        });
+        test('via NODE_OPTIONS', async () => {
+          const { err, stdout } = await exec(`${cmd} index.ts`, {
+            cwd: join(TEST_DIR, './esm-node-resolver'),
+            env: {
+              ...process.env,
+              NODE_OPTIONS: '--experimental-specifier-resolution=node',
+            },
+          });
+          expect(err).to.equal(null);
+          expect(stdout).to.equal('foo bar baz biff libfoo\n');
+        });
       });
-      expect(err).to.not.equal(null);
-      // expect error from node's default resolver
-      expect(stderr).to.match(
-        /Error \[ERR_UNSUPPORTED_ESM_URL_SCHEME\]:.*(?:\n.*){0,1}\n *at defaultResolve/
-      );
-    });
 
-    test('should bypass import cache when changing search params', async () => {
-      const { err, stdout } = await exec(`${cmd} index.ts`, {
-        cwd: join(TEST_DIR, './esm-import-cache'),
+      test('throws ERR_REQUIRE_ESM when attempting to require() an ESM script when ESM loader is enabled', async () => {
+        const { err, stderr } = await exec(`${cmd} ./index.js`, {
+          cwd: join(TEST_DIR, './esm-err-require-esm'),
+        });
+        expect(err).to.not.equal(null);
+        expect(stderr).to.contain(
+          'Error [ERR_REQUIRE_ESM]: Must use import to load ES Module:'
+        );
       });
-      expect(err).to.equal(null);
-      expect(stdout).to.equal('log1\nlog2\nlog2\n');
-    });
 
-    test('should support transpile only mode via dedicated loader entrypoint', async () => {
-      const { err, stdout } = await exec(`${cmd}/transpile-only index.ts`, {
-        cwd: join(TEST_DIR, './esm-transpile-only'),
+      test('defers to fallback loaders when URL should not be handled by ts-node', async () => {
+        const { err, stdout, stderr } = await exec(`${cmd} index.mjs`, {
+          cwd: join(TEST_DIR, './esm-import-http-url'),
+        });
+        expect(err).to.not.equal(null);
+        // expect error from node's default resolver
+        expect(stderr).to.match(
+          /Error \[ERR_UNSUPPORTED_ESM_URL_SCHEME\]:.*(?:\n.*){0,1}\n *at defaultResolve/
+        );
       });
-      expect(err).to.equal(null);
-      expect(stdout).to.equal('');
-    });
-    test('should throw type errors without transpile-only enabled', async () => {
-      const { err, stdout } = await exec(`${cmd} index.ts`, {
-        cwd: join(TEST_DIR, './esm-transpile-only'),
-      });
-      if (err === null) {
-        throw new Error('Command was expected to fail, but it succeeded.');
-      }
 
-      expect(err.message).to.contain('Unable to compile TypeScript');
-      expect(err.message).to.match(
-        new RegExp(
-          "TS2345: Argument of type '(?:number|1101)' is not assignable to parameter of type 'string'\\."
-        )
-      );
-      expect(err.message).to.match(
-        new RegExp(
-          "TS2322: Type '(?:\"hello world\"|string)' is not assignable to type 'number'\\."
-        )
-      );
-      expect(stdout).to.equal('');
-    });
+      test('should bypass import cache when changing search params', async () => {
+        const { err, stdout } = await exec(`${cmd} index.ts`, {
+          cwd: join(TEST_DIR, './esm-import-cache'),
+        });
+        expect(err).to.equal(null);
+        expect(stdout).to.equal('log1\nlog2\nlog2\n');
+      });
+
+      test('should support transpile only mode via dedicated loader entrypoint', async () => {
+        const { err, stdout } = await exec(`${cmd}/transpile-only index.ts`, {
+          cwd: join(TEST_DIR, './esm-transpile-only'),
+        });
+        expect(err).to.equal(null);
+        expect(stdout).to.equal('');
+      });
+      test('should throw type errors without transpile-only enabled', async () => {
+        const { err, stdout } = await exec(`${cmd} index.ts`, {
+          cwd: join(TEST_DIR, './esm-transpile-only'),
+        });
+        if (err === null) {
+          throw new Error('Command was expected to fail, but it succeeded.');
+        }
+
+        expect(err.message).to.contain('Unable to compile TypeScript');
+        expect(err.message).to.match(
+          new RegExp(
+            "TS2345: Argument of type '(?:number|1101)' is not assignable to parameter of type 'string'\\."
+          )
+        );
+        expect(err.message).to.match(
+          new RegExp(
+            "TS2322: Type '(?:\"hello world\"|string)' is not assignable to type 'number'\\."
+          )
+        );
+        expect(stdout).to.equal('');
+      });
+    }
 
     if (semver.gte(process.version, '12.0.0')) {
       test('throws ERR_REQUIRE_ESM when attempting to require() an ESM script when ESM loader is *not* enabled and node version is >= 12', async () => {

--- a/tests/esm-node-resolver/index.ts
+++ b/tests/esm-node-resolver/index.ts
@@ -4,6 +4,11 @@ import { baz } from './baz';
 import { biff } from './biff';
 import { libfoo } from 'libfoo';
 
+// Test import builtin modules
+import { readFileSync } from 'fs';
+if (typeof readFileSync !== 'function')
+  throw new Error('failed to import builtin module');
+
 if (typeof module !== 'undefined')
   throw new Error('module should not exist in ESM');
 


### PR DESCRIPTION
Fixes #1331 

Adds node 12.16 to the test matrix
Run ESM tests on node 12.16 and up; previously was skipping them on <13
Updates tests to pass `--experimental-modules` where demanded by old versions of node
Add native module test to `./tests/esm-node-resolver` to match `./tests/esm`
