### PR TITLE
Put "ts-node" object at the top of `--showConfig` output

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -204,16 +204,18 @@ export function main(
       );
       process.exit(1);
     }
-    const json = ts.convertToTSConfig(
-      service.config,
-      service.configFilePath ?? join(cwd, 'ts-node-implicit-tsconfig.json'),
-      service.ts.sys
-    );
-    json['ts-node'] = {
-      ...service.options,
-      experimentalEsmLoader: undefined,
-      compilerOptions: undefined,
-      project: service.configFilePath ?? service.options.project,
+    const json = {
+      ['ts-node']: {
+        ...service.options,
+        experimentalEsmLoader: undefined,
+        compilerOptions: undefined,
+        project: service.configFilePath ?? service.options.project,
+      },
+      ...ts.convertToTSConfig(
+        service.config,
+        service.configFilePath ?? join(cwd, 'ts-node-implicit-tsconfig.json'),
+        service.ts.sys
+      ),
     };
     console.log(
       // Assumes that all configuration options which can possibly be specified via the CLI are JSON-compatible.

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -910,7 +910,6 @@ test.suite('ts-node', (test) => {
                 outDir: './.ts-node',
                 module: 'commonjs',
               },
-
             },
             null,
             2

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -888,6 +888,12 @@ test.suite('ts-node', (test) => {
           stdout,
           JSON.stringify(
             {
+              'ts-node': {
+                cwd: native(`${ROOT_DIR}/tests`),
+                projectSearchDir: native(`${ROOT_DIR}/tests`),
+                project: native(`${ROOT_DIR}/tests/tsconfig.json`),
+                require: [],
+              },
               compilerOptions: {
                 target: 'es6',
                 jsx: 'react',
@@ -904,12 +910,7 @@ test.suite('ts-node', (test) => {
                 outDir: './.ts-node',
                 module: 'commonjs',
               },
-              'ts-node': {
-                cwd: native(`${ROOT_DIR}/tests`),
-                projectSearchDir: native(`${ROOT_DIR}/tests`),
-                project: native(`${ROOT_DIR}/tests/tsconfig.json`),
-                require: [],
-              },
+
             },
             null,
             2


### PR DESCRIPTION
Having it at the bottom makes it less obvious, especially when checking for the discovered config's path.