### PR TITLE
Disk cache prototype

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,7 +4,7 @@ import { join, resolve, dirname, parse as parsePath } from 'path';
 import { inspect } from 'util';
 import Module = require('module');
 import arg = require('arg');
-import { parse, createRequire } from './util';
+import { parse, createRequire, hasOwnProperty } from './util';
 import { EVAL_FILENAME, EvalState, createRepl, ReplService } from './repl';
 import { VERSION, TSError, register } from './index';
 import type { TSInternal } from './ts-compiler-types';
@@ -371,11 +371,6 @@ function evalAndExit(
   if (isPrinted) {
     console.log(typeof result === 'string' ? result : inspect(result));
   }
-}
-
-/** Safe `hasOwnProperty` */
-function hasOwnProperty(object: any, property: string): boolean {
-  return Object.prototype.hasOwnProperty.call(object, property);
 }
 
 if (require.main === module) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -16,22 +16,19 @@ export function createCache<T>(cacheString?: string) {
   }
   const cache = _cache;
   let dirty = false;
-  function getSubcacheOf(subcache: any, key: string) {
+  function getRoot() {
+    return cache;
+  }
+  function getSubcache(subcache: any, key: string) {
     return hasOwnProperty(subcache, key) ? subcache[key] : undefined;
   }
-  function getSubcacheOfRootCache(key: string) {
-    return getSubcacheOf(cache, key);
-  }
-  function getOrCreateSubcacheOf(subcache: any, key: string) {
+  function getOrCreateSubcache(subcache: any, key: string) {
     if(hasOwnProperty(subcache, key)) {
       return subcache[key];
     }
     const newSubcache = {};
     subcache[key] = newSubcache;
     return newSubcache;
-  }
-  function getOrCreateSubcacheOfRoot(key: string) {
-    return getOrCreateSubcacheOf(cache, key);
   }
   function setEntry(cacheFrom: any, subcacheKey: string, value: T) {
     cacheFrom[subcacheKey] = value;
@@ -40,7 +37,7 @@ export function createCache<T>(cacheString?: string) {
   function getEntry(cacheFrom: any, subcacheKey: string): T {
     return hasOwnProperty(cacheFrom, subcacheKey) ? cacheFrom[subcacheKey] : undefined;
   }
-  function getCacheAsString() {
+  function serializeToString() {
     return JSON.stringify(cache);
   }
   function registerCallbackOnProcessExitAndDirty(cb: Function) {
@@ -51,5 +48,5 @@ export function createCache<T>(cacheString?: string) {
     });
   }
 
-  return {getOrCreateSubcacheOf, getOrCreateSubcacheOfRoot, getSubcacheOfRootCache, getEntry, getSubcacheOf, setEntry, getCacheAsString, registerCallbackOnProcessExitAndDirty};
+  return {getOrCreateSubcache, getEntry, getSubcache, setEntry, serializeToString, registerCallbackOnProcessExitAndDirty, getRoot};
 }

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,49 @@
+import {hasOwnProperty} from './util';
+/*
+ * cache entries are stored by: (via nested JS objects)
+ * - project hash (ts-node, ts, swc version numbers, config object hash)
+ * - abs file path
+ * - file size
+ * - file hash
+ */
+
+export function createCache<T>(cacheString: string) {
+  const cache = JSON.parse(cacheString);
+  let dirty = false;
+  function getSubcacheOf(subcache: any, key: string) {
+    return hasOwnProperty(subcache, key) ? subcache[key] : undefined;
+  }
+  function getSubcacheOfRootCache(key: string) {
+    return getSubcacheOf(cache, key);
+  }
+  function getOrCreateSubcacheOf(subcache: any, key: string) {
+    if(hasOwnProperty(subcache, key)) {
+      return subcache[key];
+    }
+    const newSubcache = {};
+    subcache[key] = newSubcache;
+    return newSubcache;
+  }
+  function getOrCreateSubcacheOfRoot(key: string) {
+    return getOrCreateSubcacheOf(cache, key);
+  }
+  function setEntry(cacheFrom: any, subcacheKey: string, value: T) {
+    cacheFrom[subcacheKey] = value;
+    dirty = true;
+  }
+  function getEntry(cacheFrom: any, subcacheKey: string): T {
+    return hasOwnProperty(cacheFrom, subcacheKey) ? cacheFrom[subcacheKey] : undefined;
+  }
+  function getCacheAsString() {
+    return JSON.stringify(cache);
+  }
+  function registerCallbackOnProcessExitAndDirty(cb: Function) {
+    process.on('exit', () => {
+      if(dirty) {
+        cb();
+      }
+    });
+  }
+
+  return {getOrCreateSubcacheOf, getOrCreateSubcacheOfRoot, getSubcacheOfRootCache, getEntry, getSubcacheOf, setEntry, getCacheAsString, registerCallbackOnProcessExitAndDirty};
+}

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -7,8 +7,14 @@ import {hasOwnProperty} from './util';
  * - file hash
  */
 
-export function createCache<T>(cacheString: string) {
-  const cache = JSON.parse(cacheString);
+export function createCache<T>(cacheString?: string) {
+  let _cache = {};
+  if(cacheString) {
+    try {
+      _cache = JSON.parse(cacheString);
+    } catch(e) {}
+  }
+  const cache = _cache;
   let dirty = false;
   function getSubcacheOf(subcache: any, key: string) {
     return hasOwnProperty(subcache, key) ? subcache[key] : undefined;

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -1,4 +1,4 @@
-import {readFileSync, writeFileSync} from 'fs';
+import {existsSync, readFileSync, writeFileSync} from 'fs';
 import type * as ts from 'typescript';
 import type * as swcWasm from '@swc/wasm';
 import type * as swcTypes from '@swc/core';
@@ -114,7 +114,7 @@ export function create(createOptions: SwcTranspilerOptions): Transpiler {
     return result;
   };
 
-  const cacheApi = createCache(readFileSync('./swc-cache.json', 'utf16le'));
+  const cacheApi = createCache(existsSync('./swc-cache.json') ? readFileSync('./swc-cache.json', 'utf16le') : undefined);
   const baseCache = cacheApi.getOrCreateSubcacheOfRoot('TODO build a hash of versions and config');
   cacheApi.registerCallbackOnProcessExitAndDirty(() => {
     writeFileSync('./swc-cache.json', cacheApi.getCacheAsString(), 'utf16le');

--- a/src/util.ts
+++ b/src/util.ts
@@ -61,3 +61,8 @@ export function parse(value: string | undefined): object | undefined {
 export function normalizeSlashes(value: string): string {
   return value.replace(/\\/g, '/');
 }
+
+/** Safe `hasOwnProperty` */
+export function hasOwnProperty(object: any, property: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, property);
+}


### PR DESCRIPTION
Disk caching prototype.  Created in the SWC integration, but should be generalized to support `transpileModule`, too.  swc is so fast that caching doesn't really help at all, so this would only be useful for `transpileModule`.

Closes #908
Closes #951