### PR TITLE
fix: prevent implicit 'use strict' output

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -214,12 +214,21 @@ function _eval(service: Service, state: EvalState, input: string) {
   const undo = appendEval(state, input);
   let output: string;
 
+  // Based on https://github.com/nodejs/node/blob/92573721c7cff104ccb82b6ed3e8aa69c4b27510/lib/repl.js#L457-L461
+  function adjustUseStrict(code: string) {
+    // "void 0" keeps the repl from returning "use strict" as the result
+    // value for statements and declarations that don't return a value.
+    return code.replace(/^"use strict";/, '"use strict"; void 0;');
+  }
+
   try {
     output = service.compile(state.input, state.path, -lines);
   } catch (err) {
     undo();
     throw err;
   }
+
+  output = adjustUseStrict(output);
 
   // Use `diff` to check for new JavaScript to execute.
   const changes = diffLines(state.output, output);

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -407,7 +407,7 @@ test.suite('ts-node', (test) => {
       const { err, stdout } = await execPromise;
       expect(err).to.equal(null);
       expect(stdout).to.equal(
-        "> 'use strict'\n" + '> undefined\n' + '> const a: 123\n' + '> '
+        '> undefined\n' + '> undefined\n' + '> const a: 123\n' + '> '
       );
     });
 
@@ -439,7 +439,7 @@ test.suite('ts-node', (test) => {
       stderr.end();
       expect(await getStream(stderr)).to.equal('');
       expect(await getStream(stdout)).to.equal(
-        "> 'use strict'\n" + '> undefined\n' + '> const a: 123\n' + '> '
+        '> undefined\n' + '> undefined\n' + '> const a: 123\n' + '> '
       );
     });
 


### PR DESCRIPTION
Fixes #1387 