### PR TITLE
chore: normalize npm version in ci jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,6 +21,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 16
+      # downgrade npm to v6 since v7 is not installing TS 2.7 correctly
+      - run: npm install -g npm@6
       - run: |
           npm config set cache "$( node -p "process.cwd()" )/temp/npm-cache"
       - name: Cache dependencies
@@ -99,19 +101,16 @@ jobs:
             nodeFlag: 16
             typescript: latest
             typescriptFlag: latest
-            downgradeNpm: true
           - flavor: 9
             node: 16
             nodeFlag: 16
             typescript: 2.7
             typescriptFlag: 2_7
-            downgradeNpm: true
           - flavor: 10
             node: 16
             nodeFlag: 16
             typescript: next
             typescriptFlag: next
-            downgradeNpm: true
     steps:
       # checkout code
       - uses: actions/checkout@v2
@@ -120,10 +119,8 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      # lint, build, test
-        # Downgrade from npm 7 to 6 because 7 still seems buggy to me
-      - if: ${{ matrix.downgradeNpm }}
-        run: npm install -g npm@6
+      # Install same npm version that populated the cache
+      - run: npm install -g npm@6
       - run: |
           npm config set cache "$( node -p "process.cwd()" )/temp/npm-cache"
       - name: Cache dependencies
@@ -132,6 +129,7 @@ jobs:
           path: temp/npm-cache
           key: npm-cache-${{ matrix.os }}-${{ hashFiles('package-lock.json') }}
           restore-keys: npm-cache-${{matrix.os }}-
+      # lint, build, test
       - run: npm ci --ignore-scripts
       - name: Upload npm logs
         if: ${{ failure() }}


### PR DESCRIPTION
Having 2 different versions of `npm` could lead to issues causing the jobs to randomly fail.

Related:
https://github.com/actions/setup-node/issues/268
https://github.com/npm/cli/issues/417