### PR TITLE
Set of extra ignored diagnostics for REPL mode

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -205,7 +205,7 @@ export function main(
       repl: createRepl({
         state,
         composeWithEvalAwarePartialHost: evalAwarePartialHost,
-        ignoreExtraDiagnostics: false,
+        ignoreDiagnosticsThatAreAnnoyingInInteractiveRepl: false,
       }),
     };
     ({ evalAwarePartialHost } = evalStuff.repl);
@@ -221,7 +221,7 @@ export function main(
       repl: createRepl({
         state,
         composeWithEvalAwarePartialHost: evalAwarePartialHost,
-        ignoreExtraDiagnostics: false,
+        ignoreDiagnosticsThatAreAnnoyingInInteractiveRepl: false,
       }),
     };
     ({ evalAwarePartialHost } = stdinStuff.repl);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -205,6 +205,7 @@ export function main(
       repl: createRepl({
         state,
         composeWithEvalAwarePartialHost: evalAwarePartialHost,
+        ignoreExtraDiagnostics: false,
       }),
     };
     ({ evalAwarePartialHost } = evalStuff.repl);
@@ -220,6 +221,7 @@ export function main(
       repl: createRepl({
         state,
         composeWithEvalAwarePartialHost: evalAwarePartialHost,
+        ignoreExtraDiagnostics: false,
       }),
     };
     ({ evalAwarePartialHost } = stdinStuff.repl);

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -197,11 +197,6 @@ export function main(
   let evalStuff: VirtualFileState | undefined;
   let replStuff: VirtualFileState | undefined;
   let stdinStuff: VirtualFileState | undefined;
-  // let evalService: ReplService | undefined;
-  // let replState: EvalState | undefined;
-  // let replService: ReplService | undefined;
-  // let stdinState: EvalState | undefined;
-  // let stdinService: ReplService | undefined;
   let evalAwarePartialHost: EvalAwarePartialHost | undefined = undefined;
   if (executeEval) {
     const state = new EvalState(join(cwd, EVAL_FILENAME));

--- a/src/index.ts
+++ b/src/index.ts
@@ -528,16 +528,18 @@ export function create(rawOptions: CreateOptions = {}): Service {
   const transpileOnly =
     options.transpileOnly === true && options.typeCheck !== true;
   const transformers = options.transformers || undefined;
-  const diagnosticFilters: Array<DiagnosticFilter> = [{
-    appliesToAllFiles: true,
-    filenamesAbsolute: [],
-    diagnosticsIgnored: [
-      6059, // "'rootDir' is expected to contain all source files."
-      18002, // "The 'files' list in config file is empty."
-      18003, // "No inputs were found in config file."
-      ...(options.ignoreDiagnostics || []),
-    ].map(Number)
-  }];
+  const diagnosticFilters: Array<DiagnosticFilter> = [
+    {
+      appliesToAllFiles: true,
+      filenamesAbsolute: [],
+      diagnosticsIgnored: [
+        6059, // "'rootDir' is expected to contain all source files."
+        18002, // "The 'files' list in config file is empty."
+        18003, // "No inputs were found in config file."
+        ...(options.ignoreDiagnostics || []),
+      ].map(Number),
+    },
+  ];
 
   const configDiagnosticList = filterDiagnostics(
     config.errors,
@@ -1157,6 +1159,10 @@ export function create(rawOptions: CreateOptions = {}): Service {
     return true;
   };
 
+  function addDiagnosticFilter(filter: DiagnosticFilter) {
+    diagnosticFilters.push(filter);
+  }
+
   return {
     ts,
     config,
@@ -1167,6 +1173,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
     options,
     configFilePath,
     moduleTypeClassifier,
+    addDiagnosticFilter,
   };
 }
 
@@ -1324,8 +1331,13 @@ function filterDiagnostics(
   diagnostics: readonly _ts.Diagnostic[],
   filters: DiagnosticFilter[]
 ) {
-  return diagnostics.filter(d =>
-    filters.every(f => (!f.appliesToAllFiles && f.filenamesAbsolute.indexOf(d.file?.fileName!) === -1) || f.diagnosticsIgnored.indexOf(d.code) === -1)
+  return diagnostics.filter((d) =>
+    filters.every(
+      (f) =>
+        (!f.appliesToAllFiles &&
+          f.filenamesAbsolute.indexOf(d.file?.fileName!) === -1) ||
+        f.diagnosticsIgnored.indexOf(d.code) === -1
+    )
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -410,6 +410,8 @@ export interface Service {
   configFilePath: string | undefined;
   /** @internal */
   moduleTypeClassifier: ModuleTypeClassifier;
+  /** @internal */
+  addDiagnosticFilter(filter: DiagnosticFilter): void;
 }
 
 /**
@@ -418,6 +420,16 @@ export interface Service {
  * @see {Service}
  */
 export type Register = Service;
+
+/** @internal */
+export interface DiagnosticFilter {
+  /** if true, filter applies to all files */
+  appliesToAllFiles: boolean;
+  /** Filter applies onto to these filenames.  Only used if appliesToAllFiles is false */
+  filenamesAbsolute: string[];
+  /** these diagnostic codes are ignored */
+  diagnosticsIgnored: number[];
+}
 
 /** @internal */
 export function getExtensions(config: _ts.ParsedCommandLine) {
@@ -516,16 +528,20 @@ export function create(rawOptions: CreateOptions = {}): Service {
   const transpileOnly =
     options.transpileOnly === true && options.typeCheck !== true;
   const transformers = options.transformers || undefined;
-  const ignoreDiagnostics = [
-    6059, // "'rootDir' is expected to contain all source files."
-    18002, // "The 'files' list in config file is empty."
-    18003, // "No inputs were found in config file."
-    ...(options.ignoreDiagnostics || []),
-  ].map(Number);
+  const diagnosticFilters: Array<DiagnosticFilter> = [{
+    appliesToAllFiles: true,
+    filenamesAbsolute: [],
+    diagnosticsIgnored: [
+      6059, // "'rootDir' is expected to contain all source files."
+      18002, // "The 'files' list in config file is empty."
+      18003, // "No inputs were found in config file."
+      ...(options.ignoreDiagnostics || []),
+    ].map(Number)
+  }];
 
   const configDiagnosticList = filterDiagnostics(
     config.errors,
-    ignoreDiagnostics
+    diagnosticFilters
   );
   const outputCache = new Map<
     string,
@@ -804,7 +820,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
 
         const diagnosticList = filterDiagnostics(
           diagnostics,
-          ignoreDiagnostics
+          diagnosticFilters
         );
         if (diagnosticList.length) reportTSError(diagnosticList);
 
@@ -963,7 +979,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
         const diagnostics = ts.getPreEmitDiagnostics(program, sourceFile);
         const diagnosticList = filterDiagnostics(
           diagnostics,
-          ignoreDiagnostics
+          diagnosticFilters
         );
         if (diagnosticList.length) reportTSError(diagnosticList);
 
@@ -1079,7 +1095,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
 
       const diagnosticList = filterDiagnostics(
         result.diagnostics || [],
-        ignoreDiagnostics
+        diagnosticFilters
       );
       if (diagnosticList.length) reportTSError(diagnosticList);
 
@@ -1306,9 +1322,11 @@ function updateSourceMap(sourceMapText: string, fileName: string) {
  */
 function filterDiagnostics(
   diagnostics: readonly _ts.Diagnostic[],
-  ignore: number[]
+  filters: DiagnosticFilter[]
 ) {
-  return diagnostics.filter((x) => ignore.indexOf(x.code) === -1);
+  return diagnostics.filter(d =>
+    filters.every(f => (!f.appliesToAllFiles && f.filenamesAbsolute.indexOf(d.file?.fileName!) === -1) || f.diagnosticsIgnored.indexOf(d.code) === -1)
+  );
 }
 
 /**

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -59,6 +59,11 @@ export interface CreateReplOptions {
   stderr?: NodeJS.WritableStream;
   /** @internal */
   composeWithEvalAwarePartialHost?: EvalAwarePartialHost;
+  /**
+   * @internal
+   * Ignore diagnostics that are annoying when interactively entering input line-by-line
+   */
+  ignoreExtraDiagnostics?: boolean;
 }
 
 /**
@@ -86,6 +91,7 @@ export function createRepl(options: CreateReplOptions = {}) {
     stdout === process.stdout && stderr === process.stderr
       ? console
       : new Console(stdout, stderr);
+  const {ignoreExtraDiagnostics = true} = options;
 
   const replService: ReplService = {
     state: options.state ?? new EvalState(join(process.cwd(), EVAL_FILENAME)),
@@ -103,16 +109,17 @@ export function createRepl(options: CreateReplOptions = {}) {
 
   function setService(_service: Service) {
     service = _service;
-    // Ignore these diagnostics when they occur in the virtual REPL file
-    service.addDiagnosticFilter({
-      appliesToAllFiles: false,
-      filenamesAbsolute: [state.path],
-      diagnosticsIgnored: [
-        2393, // Duplicate function implementation: https://github.com/TypeStrong/ts-node/issues/729
-        6133, // <identifier> is declared but its value is never read. https://github.com/TypeStrong/ts-node/issues/850
-        7027, // Unreachable code detected. https://github.com/TypeStrong/ts-node/issues/469
-      ]
-    });
+    if(ignoreExtraDiagnostics) {
+      service.addDiagnosticFilter({
+        appliesToAllFiles: false,
+        filenamesAbsolute: [state.path],
+        diagnosticsIgnored: [
+          2393, // Duplicate function implementation: https://github.com/TypeStrong/ts-node/issues/729
+          6133, // <identifier> is declared but its value is never read. https://github.com/TypeStrong/ts-node/issues/850
+          7027, // Unreachable code detected. https://github.com/TypeStrong/ts-node/issues/469
+        ]
+      });
+    }
   }
 
   function evalCode(code: string) {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -103,6 +103,16 @@ export function createRepl(options: CreateReplOptions = {}) {
 
   function setService(_service: Service) {
     service = _service;
+    // Ignore these diagnostics when they occur in the virtual REPL file
+    service.addDiagnosticFilter({
+      appliesToAllFiles: false,
+      filenamesAbsolute: [state.path],
+      diagnosticsIgnored: [
+        2393, // Duplicate function implementation: https://github.com/TypeStrong/ts-node/issues/729
+        6133, // <identifier> is declared but its value is never read. https://github.com/TypeStrong/ts-node/issues/850
+        7027, // Unreachable code detected. https://github.com/TypeStrong/ts-node/issues/469
+      ]
+    });
   }
 
   function evalCode(code: string) {

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -61,9 +61,9 @@ export interface CreateReplOptions {
   composeWithEvalAwarePartialHost?: EvalAwarePartialHost;
   /**
    * @internal
-   * Ignore diagnostics that are annoying when interactively entering input line-by-line
+   * Ignore diagnostics that are annoying when interactively entering input line-by-line.
    */
-  ignoreExtraDiagnostics?: boolean;
+  ignoreDiagnosticsThatAreAnnoyingInInteractiveRepl?: boolean;
 }
 
 /**
@@ -91,7 +91,7 @@ export function createRepl(options: CreateReplOptions = {}) {
     stdout === process.stdout && stderr === process.stderr
       ? console
       : new Console(stdout, stderr);
-  const { ignoreExtraDiagnostics = true } = options;
+  const { ignoreDiagnosticsThatAreAnnoyingInInteractiveRepl = true } = options;
 
   const replService: ReplService = {
     state: options.state ?? new EvalState(join(process.cwd(), EVAL_FILENAME)),
@@ -109,7 +109,7 @@ export function createRepl(options: CreateReplOptions = {}) {
 
   function setService(_service: Service) {
     service = _service;
-    if (ignoreExtraDiagnostics) {
+    if (ignoreDiagnosticsThatAreAnnoyingInInteractiveRepl) {
       service.addDiagnosticFilter({
         appliesToAllFiles: false,
         filenamesAbsolute: [state.path],

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -91,7 +91,7 @@ export function createRepl(options: CreateReplOptions = {}) {
     stdout === process.stdout && stderr === process.stderr
       ? console
       : new Console(stdout, stderr);
-  const {ignoreExtraDiagnostics = true} = options;
+  const { ignoreExtraDiagnostics = true } = options;
 
   const replService: ReplService = {
     state: options.state ?? new EvalState(join(process.cwd(), EVAL_FILENAME)),
@@ -109,7 +109,7 @@ export function createRepl(options: CreateReplOptions = {}) {
 
   function setService(_service: Service) {
     service = _service;
-    if(ignoreExtraDiagnostics) {
+    if (ignoreExtraDiagnostics) {
       service.addDiagnosticFilter({
         appliesToAllFiles: false,
         filenamesAbsolute: [state.path],
@@ -117,7 +117,7 @@ export function createRepl(options: CreateReplOptions = {}) {
           2393, // Duplicate function implementation: https://github.com/TypeStrong/ts-node/issues/729
           6133, // <identifier> is declared but its value is never read. https://github.com/TypeStrong/ts-node/issues/850
           7027, // Unreachable code detected. https://github.com/TypeStrong/ts-node/issues/469
-        ]
+        ],
       });
     }
   }

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -453,7 +453,6 @@ test.suite('ts-node', (test) => {
     test.suite(
       '[eval], <repl>, and [stdin] execute with correct globals',
       (test) => {
-        cmd;
         interface GlobalInRepl extends NodeJS.Global {
           testReport: any;
           replReport: any;
@@ -1137,9 +1136,7 @@ test.suite('ts-node', (test) => {
       test('should locate tsconfig relative to cwd in --cwd-mode', async () => {
         const { err, stdout } = await exec(
           `${BIN_PATH} --cwd-mode ../a/index`,
-          {
-            cwd: join(TEST_DIR, 'cwd-and-script-mode/b'),
-          }
+          { cwd: join(TEST_DIR, 'cwd-and-script-mode/b') }
         );
         expect(err).to.equal(null);
         expect(stdout).to.match(/plugin-b/);
@@ -1289,12 +1286,11 @@ test.suite('ts-node', (test) => {
             const {
               context: { tempDir },
             } = t;
-            const { err: err1, stdout: stdout1, stderr: stderr1 } = await exec(
-              `${BIN_PATH} --showConfig`,
-              {
-                cwd: tempDir,
-              }
-            );
+            const {
+              err: err1,
+              stdout: stdout1,
+              stderr: stderr1,
+            } = await exec(`${BIN_PATH} --showConfig`, { cwd: tempDir });
             expect(err1).to.equal(null);
             t.like(JSON.parse(stdout1), {
               compilerOptions: {
@@ -1803,21 +1799,23 @@ test.suite('ts-node', (test) => {
 
       test.suite('supports experimental-specifier-resolution=node', (test) => {
         test('via --experimental-specifier-resolution', async () => {
-          const { err, stdout } = await exec(
+          const {
+            err,
+            stdout,
+          } = await exec(
             `${esmCmd} --experimental-specifier-resolution=node index.ts`,
-            {
-              cwd: join(TEST_DIR, './esm-node-resolver'),
-            }
+            { cwd: join(TEST_DIR, './esm-node-resolver') }
           );
           expect(err).to.equal(null);
           expect(stdout).to.equal('foo bar baz biff libfoo\n');
         });
         test('via --es-module-specifier-resolution alias', async () => {
-          const { err, stdout } = await exec(
+          const {
+            err,
+            stdout,
+          } = await exec(
             `${esmCmd} --experimental-modules --es-module-specifier-resolution=node index.ts`,
-            {
-              cwd: join(TEST_DIR, './esm-node-resolver'),
-            }
+            { cwd: join(TEST_DIR, './esm-node-resolver') }
           );
           expect(err).to.equal(null);
           expect(stdout).to.equal('foo bar baz biff libfoo\n');

--- a/src/test/macros.ts
+++ b/src/test/macros.ts
@@ -1,0 +1,111 @@
+import type { ChildProcess, ExecException, ExecOptions } from "child_process";
+import {exec as childProcessExec} from 'child_process';
+import type { TestInterface } from "./testlib";
+import { expect } from 'chai';
+import * as exp from 'expect';
+
+export type ExecReturn = Promise<ExecResult> & {child: ChildProcess};
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  err: null | ExecException;
+  child: ChildProcess;
+}
+
+export interface ExecMacroOptions {
+  titlePrefix?: string;
+  cmd: string;
+  flags?: string;
+  cwd?: string;
+  env?: Record<string, string>;
+  stdin?: string;
+  expectError?: boolean;
+  delay?: number;
+}
+export type ExecMacroAssertionCallback = (
+          stdout: string,
+          stderr: string,
+          err: ExecException | null
+        ) => Promise<void> | void
+
+export interface createMacrosAndHelpersOptions {
+  test: TestInterface<unknown>;
+  defaultCwd: string;
+}
+export function createMacrosAndHelpers(opts: createMacrosAndHelpersOptions) {
+  const {test, defaultCwd} = opts;
+
+  /**
+   * Helper to exec a child process.
+   * Returns a Promise and a reference to the child process to suite multiple situations.
+   * Promise resolves with the process's stdout, stderr, and error.
+   */
+  function exec(
+    cmd: string,
+    opts: ExecOptions = {}
+  ): ExecReturn {
+    let child!: ChildProcess;
+    return Object.assign(
+      new Promise<ExecResult>((resolve, reject) => {
+        child = childProcessExec(
+          cmd,
+          {
+            cwd: defaultCwd,
+            ...opts,
+          },
+          (err, stdout, stderr) => {
+            resolve({ err, stdout, stderr, child });
+          }
+        );
+      }),
+      {
+        child
+      }
+    );
+  }
+
+  /**
+   * Create a macro that launches a CLI command, optionally pipes stdin, optionally sets env vars,
+   * and allows assertions against the output.
+   */
+  function createExecMacro<T extends Partial<ExecMacroOptions>>(preBoundOptions: T) {
+    return test.macro(
+      (
+        options: Pick<ExecMacroOptions, Exclude<keyof ExecMacroOptions, keyof T>> & Partial<Pick<ExecMacroOptions, keyof T & keyof ExecMacroOptions>>,
+        assertions: ExecMacroAssertionCallback
+      ) => [
+        (title) => `${options.titlePrefix ?? ''}${title}`,
+        async (t) => {
+          const {
+            cmd,
+            flags = '',
+            stdin,
+            expectError = false,
+            cwd,
+            delay = 0,
+            env,
+          } = { ...preBoundOptions, ...options };
+          const execPromise = exec(`${cmd} ${flags}`, {
+            cwd,
+            env: {...process.env, ...env},
+          });
+          if(stdin !== undefined) {
+            execPromise.child.stdin!.end(stdin);
+          }
+          const { err, stdout, stderr } = await execPromise;
+          if (expectError) {
+            exp(err).toBeDefined();
+          } else {
+            exp(err).toBeNull();
+          }
+          await assertions(stdout, stderr, err);
+        }
+      ]
+    );
+  }
+
+  return {
+    exec,
+    createExecMacro
+  };
+}

--- a/src/test/macros.ts
+++ b/src/test/macros.ts
@@ -1,10 +1,10 @@
-import type { ChildProcess, ExecException, ExecOptions } from "child_process";
-import {exec as childProcessExec} from 'child_process';
-import type { TestInterface } from "./testlib";
+import type { ChildProcess, ExecException, ExecOptions } from 'child_process';
+import { exec as childProcessExec } from 'child_process';
+import type { TestInterface } from './testlib';
 import { expect } from 'chai';
 import * as exp from 'expect';
 
-export type ExecReturn = Promise<ExecResult> & {child: ChildProcess};
+export type ExecReturn = Promise<ExecResult> & { child: ChildProcess };
 export interface ExecResult {
   stdout: string;
   stderr: string;
@@ -20,30 +20,26 @@ export interface ExecMacroOptions {
   env?: Record<string, string>;
   stdin?: string;
   expectError?: boolean;
-  delay?: number;
 }
 export type ExecMacroAssertionCallback = (
-          stdout: string,
-          stderr: string,
-          err: ExecException | null
-        ) => Promise<void> | void
+  stdout: string,
+  stderr: string,
+  err: ExecException | null
+) => Promise<void> | void;
 
 export interface createMacrosAndHelpersOptions {
   test: TestInterface<unknown>;
   defaultCwd: string;
 }
 export function createMacrosAndHelpers(opts: createMacrosAndHelpersOptions) {
-  const {test, defaultCwd} = opts;
+  const { test, defaultCwd } = opts;
 
   /**
    * Helper to exec a child process.
    * Returns a Promise and a reference to the child process to suite multiple situations.
    * Promise resolves with the process's stdout, stderr, and error.
    */
-  function exec(
-    cmd: string,
-    opts: ExecOptions = {}
-  ): ExecReturn {
+  function exec(cmd: string, opts: ExecOptions = {}): ExecReturn {
     let child!: ChildProcess;
     return Object.assign(
       new Promise<ExecResult>((resolve, reject) => {
@@ -59,7 +55,7 @@ export function createMacrosAndHelpers(opts: createMacrosAndHelpersOptions) {
         );
       }),
       {
-        child
+        child,
       }
     );
   }
@@ -68,28 +64,29 @@ export function createMacrosAndHelpers(opts: createMacrosAndHelpersOptions) {
    * Create a macro that launches a CLI command, optionally pipes stdin, optionally sets env vars,
    * and allows assertions against the output.
    */
-  function createExecMacro<T extends Partial<ExecMacroOptions>>(preBoundOptions: T) {
+  function createExecMacro<T extends Partial<ExecMacroOptions>>(
+    preBoundOptions: T
+  ) {
     return test.macro(
       (
-        options: Pick<ExecMacroOptions, Exclude<keyof ExecMacroOptions, keyof T>> & Partial<Pick<ExecMacroOptions, keyof T & keyof ExecMacroOptions>>,
+        options: Pick<
+          ExecMacroOptions,
+          Exclude<keyof ExecMacroOptions, keyof T>
+        > &
+          Partial<Pick<ExecMacroOptions, keyof T & keyof ExecMacroOptions>>,
         assertions: ExecMacroAssertionCallback
       ) => [
         (title) => `${options.titlePrefix ?? ''}${title}`,
         async (t) => {
-          const {
-            cmd,
-            flags = '',
-            stdin,
-            expectError = false,
-            cwd,
-            delay = 0,
-            env,
-          } = { ...preBoundOptions, ...options };
+          const { cmd, flags = '', stdin, expectError = false, cwd, env } = {
+            ...preBoundOptions,
+            ...options,
+          };
           const execPromise = exec(`${cmd} ${flags}`, {
             cwd,
-            env: {...process.env, ...env},
+            env: { ...process.env, ...env },
           });
-          if(stdin !== undefined) {
+          if (stdin !== undefined) {
             execPromise.child.stdin!.end(stdin);
           }
           const { err, stdout, stderr } = await execPromise;
@@ -99,13 +96,13 @@ export function createMacrosAndHelpers(opts: createMacrosAndHelpersOptions) {
             exp(err).toBeNull();
           }
           await assertions(stdout, stderr, err);
-        }
+        },
       ]
     );
   }
 
   return {
     exec,
-    createExecMacro
+    createExecMacro,
   };
 }

--- a/src/test/testlib.ts
+++ b/src/test/testlib.ts
@@ -1,3 +1,9 @@
+/*
+ * Extensions to ava, for declaring and running test cases and suites
+ * Utilities specific to testing ts-node, for example handling streams and exec-ing processes,
+ * should go in a separate module.
+ */
+
 import avaTest, {
   ExecutionContext,
   Implementation,
@@ -60,7 +66,7 @@ export interface TestInterface<
       ...args: Args
     ) =>
       | [
-          (title: string | undefined) => string,
+          (title: string | undefined) => string | undefined,
           (t: ExecutionContext<Context>) => Promise<void>
         ]
       | ((t: ExecutionContext<Context>) => Promise<void>)

--- a/tests/repl-ignored-diagnostics/index.ts
+++ b/tests/repl-ignored-diagnostics/index.ts
@@ -1,0 +1,6 @@
+// This script triggers a diagnostic that is ignored in the virtual <REPL> file but
+// *not* in files such as this one.
+// When this file is required by the REPL, the diagnostic *should* be logged.
+export {};
+function foo() {}
+function foo() {}


### PR DESCRIPTION
Closes #1120 
Closes #729
Closes #850
Closes #469

Refactors diagnostic-ignoring logic to support per-file filters.

REPL can add a filter which applies *only* to the REPL's virtual file and removes diagnostics which are annoying in interactive mode.  For example, "unreachable code" and "duplicate function declaration"

Also refactors some test macros