### PR TITLE
Fix source-map-support bugs via a fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
-        "@cspotcode/source-map-support": "0.6.0-1",
+        "@cspotcode/source-map-support": "0.6.1",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -408,19 +408,19 @@
       }
     },
     "node_modules/@cspotcode/source-map-consumer": {
-      "version": "0.8.0-1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0-1.tgz",
-      "integrity": "sha512-+Dp6FdqS+58sKCwNU+iDgpaav9e1kGWA+0Hoo55vTgMrPR8DmaazmPMQicuHeoCTDR5NfJVqCCmN8+m/L1sPCw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.6.0-1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.0-1.tgz",
-      "integrity": "sha512-Pv/0XiKMl2pZYm+Zo81znE0RxXKLkRSVhrq8vein3yChNKYQ9tzt0wEdZ46g7wxlCOweRwbJO2IqHIZwxJeWlg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
+      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
       "dependencies": {
-        "@cspotcode/source-map-consumer": "0.8.0-1"
+        "@cspotcode/source-map-consumer": "0.8.0"
       },
       "engines": {
         "node": ">=12"
@@ -6747,16 +6747,16 @@
       }
     },
     "@cspotcode/source-map-consumer": {
-      "version": "0.8.0-1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0-1.tgz",
-      "integrity": "sha512-+Dp6FdqS+58sKCwNU+iDgpaav9e1kGWA+0Hoo55vTgMrPR8DmaazmPMQicuHeoCTDR5NfJVqCCmN8+m/L1sPCw=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg=="
     },
     "@cspotcode/source-map-support": {
-      "version": "0.6.0-1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.0-1.tgz",
-      "integrity": "sha512-Pv/0XiKMl2pZYm+Zo81znE0RxXKLkRSVhrq8vein3yChNKYQ9tzt0wEdZ46g7wxlCOweRwbJO2IqHIZwxJeWlg==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
+      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
       "requires": {
-        "@cspotcode/source-map-consumer": "0.8.0-1"
+        "@cspotcode/source-map-consumer": "0.8.0"
       }
     },
     "@istanbuljs/load-nyc-config": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
+        "@cspotcode/source-map-support": "0.6.0-0",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -17,7 +18,6 @@
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
       },
       "bin": {
@@ -406,6 +406,25 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0-1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0-1.tgz",
+      "integrity": "sha512-+Dp6FdqS+58sKCwNU+iDgpaav9e1kGWA+0Hoo55vTgMrPR8DmaazmPMQicuHeoCTDR5NfJVqCCmN8+m/L1sPCw==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.6.0-0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.0-0.tgz",
+      "integrity": "sha512-XXxowLchpVje9K68UPCeNV+utii9RR9jNKsKd+VxJCoVYtIEqwhXrHeCdsD3rG+Dg7+6fQjGKyg030Z/zsNkJA==",
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0-1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -1644,16 +1663,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/ava/node_modules/source-map-support": {
-      "version": "0.5.19",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/ava/node_modules/string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -1952,7 +1961,8 @@
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
     },
     "node_modules/cacheable-request": {
       "version": "6.1.0",
@@ -5559,14 +5569,16 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.17.tgz",
-      "integrity": "sha512-bwdKOBZ5L0gFRh4KOxNap/J/MpvX9Yxsq9lFDx65s3o7F/NiHy7JRaGIS8MwW6tZPAq9UXE207Il0cfcb5yu/Q==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -6750,6 +6762,19 @@
         }
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0-1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0-1.tgz",
+      "integrity": "sha512-+Dp6FdqS+58sKCwNU+iDgpaav9e1kGWA+0Hoo55vTgMrPR8DmaazmPMQicuHeoCTDR5NfJVqCCmN8+m/L1sPCw=="
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.6.0-0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.0-0.tgz",
+      "integrity": "sha512-XXxowLchpVje9K68UPCeNV+utii9RR9jNKsKd+VxJCoVYtIEqwhXrHeCdsD3rG+Dg7+6fQjGKyg030Z/zsNkJA==",
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0-1"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -7745,16 +7770,6 @@
             "aggregate-error": "^3.0.0"
           }
         },
-        "source-map-support": {
-          "version": "0.5.19",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
-          "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-          "dev": true,
-          "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
-          }
-        },
         "string-width": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -8007,7 +8022,8 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8="
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+      "dev": true
     },
     "cacheable-request": {
       "version": "6.1.0",
@@ -10867,12 +10883,14 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "dev": true
     },
     "source-map-support": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.17.tgz",
-      "integrity": "sha512-bwdKOBZ5L0gFRh4KOxNap/J/MpvX9Yxsq9lFDx65s3o7F/NiHy7JRaGIS8MwW6tZPAq9UXE207Il0cfcb5yu/Q==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.1",
+        "@tsconfig/node16": "^1.0.2",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
@@ -1086,9 +1086,9 @@
       "integrity": "sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ=="
     },
     "node_modules/@tsconfig/node16": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
-      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
     },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
@@ -7255,9 +7255,9 @@
       "integrity": "sha512-RKkL8eTdPv6t5EHgFKIVQgsDapugbuOptNd9OOunN/HAkzmmTnZELx1kNCK0rSdUYGmiFMM3rRQMAWiyp023LQ=="
     },
     "@tsconfig/node16": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
-      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA=="
     },
     "@types/argparse": {
       "version": "1.0.38",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.1.0",
       "license": "MIT",
       "dependencies": {
-        "@cspotcode/source-map-support": "0.6.0-0",
+        "@cspotcode/source-map-support": "0.6.0-1",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
@@ -39,7 +39,6 @@
         "@types/react": "^16.0.2",
         "@types/rimraf": "^3.0.0",
         "@types/semver": "^7.1.0",
-        "@types/source-map-support": "^0.5.0",
         "@yarnpkg/fslib": "^2.4.0",
         "ava": "^3.15.0",
         "axios": "^0.21.1",
@@ -417,9 +416,9 @@
       }
     },
     "node_modules/@cspotcode/source-map-support": {
-      "version": "0.6.0-0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.0-0.tgz",
-      "integrity": "sha512-XXxowLchpVje9K68UPCeNV+utii9RR9jNKsKd+VxJCoVYtIEqwhXrHeCdsD3rG+Dg7+6fQjGKyg030Z/zsNkJA==",
+      "version": "0.6.0-1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.0-1.tgz",
+      "integrity": "sha512-Pv/0XiKMl2pZYm+Zo81znE0RxXKLkRSVhrq8vein3yChNKYQ9tzt0wEdZ46g7wxlCOweRwbJO2IqHIZwxJeWlg==",
       "dependencies": {
         "@cspotcode/source-map-consumer": "0.8.0-1"
       },
@@ -1218,15 +1217,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
       "integrity": "sha1-yMYw1MGM0ya+/3dASIdZb5ZAhAg=",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/source-map-support": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.0.tgz",
-      "integrity": "sha512-OrnAz5K5dXDgMdeRRoXIjDAvkodQ9ESvVJCyzrhzUJKmCkXgmYx/KLUBcVFe5eS4FiohfcY7YPxsdkmSwJz9wA==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -3885,12 +3875,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/json5/node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
@@ -6768,9 +6752,9 @@
       "integrity": "sha512-+Dp6FdqS+58sKCwNU+iDgpaav9e1kGWA+0Hoo55vTgMrPR8DmaazmPMQicuHeoCTDR5NfJVqCCmN8+m/L1sPCw=="
     },
     "@cspotcode/source-map-support": {
-      "version": "0.6.0-0",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.0-0.tgz",
-      "integrity": "sha512-XXxowLchpVje9K68UPCeNV+utii9RR9jNKsKd+VxJCoVYtIEqwhXrHeCdsD3rG+Dg7+6fQjGKyg030Z/zsNkJA==",
+      "version": "0.6.0-1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.0-1.tgz",
+      "integrity": "sha512-Pv/0XiKMl2pZYm+Zo81znE0RxXKLkRSVhrq8vein3yChNKYQ9tzt0wEdZ46g7wxlCOweRwbJO2IqHIZwxJeWlg==",
       "requires": {
         "@cspotcode/source-map-consumer": "0.8.0-1"
       }
@@ -7402,15 +7386,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
       "integrity": "sha1-yMYw1MGM0ya+/3dASIdZb5ZAhAg=",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/source-map-support": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@types/source-map-support/-/source-map-support-0.5.0.tgz",
-      "integrity": "sha512-OrnAz5K5dXDgMdeRRoXIjDAvkodQ9ESvVJCyzrhzUJKmCkXgmYx/KLUBcVFe5eS4FiohfcY7YPxsdkmSwJz9wA==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -9535,14 +9510,6 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "jsonfile": {

--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@tsconfig/node10": "^1.0.7",
     "@tsconfig/node12": "^1.0.7",
     "@tsconfig/node14": "^1.0.0",
-    "@tsconfig/node16": "^1.0.1",
+    "@tsconfig/node16": "^1.0.2",
     "arg": "^4.1.0",
     "create-require": "^1.1.0",
     "diff": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,7 @@
     }
   },
   "dependencies": {
+    "@cspotcode/source-map-support": "0.6.0-0",
     "@tsconfig/node10": "^1.0.7",
     "@tsconfig/node12": "^1.0.7",
     "@tsconfig/node14": "^1.0.0",
@@ -166,7 +167,6 @@
     "create-require": "^1.1.0",
     "diff": "^4.0.1",
     "make-error": "^1.1.1",
-    "source-map-support": "^0.5.17",
     "yn": "3.1.1"
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "@types/react": "^16.0.2",
     "@types/rimraf": "^3.0.0",
     "@types/semver": "^7.1.0",
-    "@types/source-map-support": "^0.5.0",
     "@yarnpkg/fslib": "^2.4.0",
     "ava": "^3.15.0",
     "axios": "^0.21.1",
@@ -158,7 +157,7 @@
     }
   },
   "dependencies": {
-    "@cspotcode/source-map-support": "0.6.0-0",
+    "@cspotcode/source-map-support": "0.6.0-1",
     "@tsconfig/node10": "^1.0.7",
     "@tsconfig/node12": "^1.0.7",
     "@tsconfig/node14": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     }
   },
   "dependencies": {
-    "@cspotcode/source-map-support": "0.6.0-1",
+    "@cspotcode/source-map-support": "0.6.1",
     "@tsconfig/node10": "^1.0.7",
     "@tsconfig/node12": "^1.0.7",
     "@tsconfig/node14": "^1.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Module } from 'module';
 import * as util from 'util';
 import { fileURLToPath } from 'url';
 
-const sourceMapSupport = require('@cspotcode/source-map-support') as typeof import('source-map-support');
+import sourceMapSupport = require('@cspotcode/source-map-support');
 import { BaseError } from 'make-error';
 import type * as _ts from 'typescript';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Module } from 'module';
 import * as util from 'util';
 import { fileURLToPath } from 'url';
 
-import sourceMapSupport = require('source-map-support');
+const sourceMapSupport = require('@cspotcode/source-map-support') as typeof import('source-map-support');
 import { BaseError } from 'make-error';
 import type * as _ts from 'typescript';
 

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1248,6 +1248,9 @@ test.suite('ts-node', (test) => {
           semver.gte(ts.version, '3.5.0') &&
           semver.gte(process.versions.node, '14.0.0')
         ) {
+          const libAndTarget = semver.gte(process.versions.node, '16.0.0')
+            ? 'es2021'
+            : 'es2020';
           test('implicitly uses @tsconfig/node14 or @tsconfig/node16 compilerOptions when both TS and node versions support it', async (t) => {
             // node14 and node16 configs are identical, hence the "or"
             const {
@@ -1261,8 +1264,8 @@ test.suite('ts-node', (test) => {
             expect(err1).to.equal(null);
             t.like(JSON.parse(stdout1), {
               compilerOptions: {
-                target: 'es2020',
-                lib: ['es2020'],
+                target: libAndTarget,
+                lib: [libAndTarget],
               },
             });
             const {


### PR DESCRIPTION
Fork lets me move a bit faster releasing these bugfixes, but I still hope the upstream project can release them, too.

https://github.com/cspotcode/source-map/
http://npm.im/@cspotcode/source-map-consumer

https://github.com/cspotcode/node-source-map-support/
http://npm.im/@cspotcode/source-map-support

Closes #1403 
Closes #1410 
Closes #1411
Closes #1412