### PR TITLE
fix: do not import typescript outside of config/project loading

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ import {
   ModuleTypeClassifier,
 } from './module-type-classifier';
 import { createResolverFunctions } from './resolver-functions';
-import { ScriptTarget } from 'typescript';
 
 export { TSCommon };
 export {
@@ -551,7 +550,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
   ];
 
   // Experimental REPL await is not compatible targets lower than ES2018
-  const targetSupportsTla = config.options.target! >= ScriptTarget.ES2018;
+  const targetSupportsTla = config.options.target! >= ts.ScriptTarget.ES2018;
   if (options.experimentalReplAwait === true && !targetSupportsTla) {
     throw new Error(
       'Experimental REPL await is not compatible with targets lower than ES2018'


### PR DESCRIPTION
EDIT from @cspotcode to track related issues: Looks like this fixes a bug introduced by #1383. Should resolve #1426, #1427, #1428.

---

Or: to resolve typescript module correctly.

The current code still has a "hard" top-level requiring for typescript, which may cause issues when installing ts-node globally and installing typescript locally (i.e. you have to install them both globally or both locally). Since we've already resolving typescript smartly in the code using `loadCompiler`, why not accessing `ScriptTarget` from the resolved one?