### PR TITLE
Add esm to project exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "./dist/bin-script.js": "./dist/bin-script.js",
     "./dist/bin-cwd": "./dist/bin-cwd.js",
     "./dist/bin-cwd.js": "./dist/bin-cwd.js",
+    "./dist/esm": "./dist/esm.js",
+    "./dist/esm.js": "./dist/esm.js",
     "./register": "./register/index.js",
     "./register/files": "./register/files.js",
     "./register/transpile-only": "./register/transpile-only.js",


### PR DESCRIPTION
Hope you're doing well!

## Background

The transformer library [typescript-transform-paths](https://github.com/LeDDGroup/typescript-transform-paths) now supports `ts-node` without a `Program` instance via `typescript-transform-paths/register` script. [This addition](https://github.com/LeDDGroup/typescript-transform-paths/commit/8c36b098a837d1ed04c04a8fb8a39a03eb0bbadf) is relatively recent.

We've just received an issue from a user trying to make it work via esm. (see: https://github.com/LeDDGroup/typescript-transform-paths/issues/134)

Because of the loader process, our recreated instance does not provide node with all it needs.

## Solution

We've added a loader to make it work, which calls `registerAndCreateEsmHooks`, with the proper options. (see: https://github.com/LeDDGroup/typescript-transform-paths/pull/135/files)

But, because the loader is an es module, we can't import from `ts-node/dist/esm`, because the file isn't in the `ts-node` `exports` section of `package.json`.

## PR Scope

This PR adds `./dist/esm.js` to exports, so it is accessible.