### PR TITLE
Update esm loader hooks API

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "test": "npm run build && npm run lint && npm run test-cov --",
     "test-local": "npm run lint && npm run build-tsc && npm run build-pack && npm run test-spec --",
     "coverage-report": "nyc report --reporter=lcov",
-    "prepare": "npm run clean && npm run build-nopack"
+    "prepare": "npm run clean && npm run build-nopack",
+    "esm-usage-example": "npm run build-tsc && cd esm-usage-example && node --experimental-specifier-resolution node --loader ../esm.mjs ./index"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/src/esm.ts
+++ b/src/esm.ts
@@ -27,7 +27,8 @@ export function registerAndCreateEsmHooks(opts?: RegisterOptions) {
     preferTsExts: tsNodeInstance.options.preferTsExts,
   });
 
-  return { resolve, getFormat, transformSource };
+  // return { resolve, getFormat, transformSource };
+  return { resolve, load };
 
   function isFileUrlOrNodeStyleSpecifier(parsed: UrlWithStringQuery) {
     // We only understand file:// URLs, but in node, the specifier can be a node-style `./foo` or `foo`
@@ -64,11 +65,23 @@ export function registerAndCreateEsmHooks(opts?: RegisterOptions) {
 
     // pathname is the path to be resolved
 
-    return nodeResolveImplementation.defaultResolve(
+    console.log('got here');
+
+    const x = nodeResolveImplementation.defaultResolve(
       specifier,
       context,
       defaultResolve
     );
+    console.log('x', x);
+    return x;
+  }
+
+  async function load(
+    url: string,
+    context: {},
+    defaultLoad: typeof load
+  ): Promise<{ format: Format }> {
+    throw new Error('load');
   }
 
   type Format = 'builtin' | 'commonjs' | 'dynamic' | 'json' | 'module' | 'wasm';


### PR DESCRIPTION
This is an attempt to fix #1372.

Currently I just added a load hook that throws but it does not get called when using node `v17.0.0-nightly20210912df22736d80`. Not sure if this is because I am doing something wrong or if the changes are not fully in nightly. This version of node does warn about the old hooks so not sure what is going on yet. Will try again with tomorrows nightly of node.