### PR TITLE
swc transpiler returns undefined after first value is echoed

### DIFF
--- a/src/test/repl/repl.spec.ts
+++ b/src/test/repl/repl.spec.ts
@@ -30,6 +30,16 @@ test('should run REPL when --interactive passed and stdin is not a TTY', async (
   expect(stdout).toBe('> 123\n' + 'undefined\n' + '> ');
 });
 
+test('should echo a value when using the swc transpiler', async () => {
+  const execPromise = exec(
+    `${CMD_TS_NODE_WITH_PROJECT_FLAG} --interactive  --transpiler ts-node/transpilers/swc-experimental`
+  );
+  execPromise.child.stdin!.end('400\n401\n');
+  const { err, stdout } = await execPromise;
+  expect(err).toBe(null);
+  expect(stdout).toBe('> 400\n>401\n > ');
+});
+
 test('REPL has command to get type information', async () => {
   const execPromise = exec(`${CMD_TS_NODE_WITH_PROJECT_FLAG} --interactive`);
   execPromise.child.stdin!.end('\nconst a = 123\n.type a');


### PR DESCRIPTION
This test passes w/o the `--transpiler` argument. I',m not sure if it's an `swc` or `ts-node` bug. I'll dig around, but maybe someone can point me in the right direction?