### PR TITLE
Fix REPL bug with previous line carryover

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -208,23 +208,13 @@ export function createRepl(options: CreateReplOptions = {}) {
     context: Context;
   }) {
     const { code, enableTopLevelAwait, context } = options;
-    const result = appendCompileAndEvalInput({
+    return appendCompileAndEvalInput({
       service: service!,
       state,
       input: code,
       enableTopLevelAwait,
       context,
     });
-    // A semicolon is added to make sure that the code doesn't interact with the next line,
-    // for example to prevent `2\n+ 2` from producing 4.
-    // This is safe since the output will not change since we can only get here with successful inputs,
-    // and adding a semicolon to the end of a successful input won't ever change the output.
-    // We check to make sure the previous line ends in a newline just in case, even though it should
-    // always be the case.
-    if (state.input.charAt(state.input.length - 1) === '\n') {
-      state.input = `${state.input.slice(0, -1)};\n`;
-    }
-    return result;
   }
 
   function nodeEval(
@@ -520,6 +510,12 @@ function appendCompileAndEvalInput(options: {
     undo();
   } else {
     state.output = output;
+
+    // Insert a semicolon to make sure that the code doesn't interact with the next line,
+    // for example to prevent `2\n+ 2` from producing 4.
+    // This is safe since the output will not change since we can only get here with successful inputs,
+    // and adding a semicolon to the end of a successful input won't ever change the output.
+    state.input = `${state.input.slice(0, -1)};\n`;
   }
 
   let commands: Array<{ mustAwait?: true; execCommand: () => any }> = [];

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -217,14 +217,13 @@ export function createRepl(options: CreateReplOptions = {}) {
     });
     // A semicolon is added to make sure that the code doesn't interact with the next line,
     // for example to prevent `2\n+ 2` from producing 4.
-    // We don't care about the result so we just toss it.
-    appendCompileAndEvalInput({
-      service: service!,
-      state,
-      input: ';\n',
-      enableTopLevelAwait,
-      context,
-    });
+    // This is safe since the output will not change since we can only get here with successful inputs,
+    // and adding a semicolon to the end of a successful input won't ever change the output.
+    // We check to make sure the previous line ends in a newline just in case, even though it should
+    // always be the case.
+    if (/\n$/.test(state.input)) {
+      state.input = state.input.slice(0, state.input.length - 1) + ';\n';
+    }
     return result;
   }
 

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -208,13 +208,24 @@ export function createRepl(options: CreateReplOptions = {}) {
     context: Context;
   }) {
     const { code, enableTopLevelAwait, context } = options;
-    return appendCompileAndEvalInput({
+    const result = appendCompileAndEvalInput({
       service: service!,
       state,
       input: code,
       enableTopLevelAwait,
       context,
     });
+    // A semicolon is added to make sure that the code doesn't interact with the next line,
+    // for example to prevent `2\n+ 2` from producing 4.
+    // We don't care about the result so we just toss it.
+    appendCompileAndEvalInput({
+      service: service!,
+      state,
+      input: ';\n',
+      enableTopLevelAwait,
+      context,
+    });
+    return result;
   }
 
   function nodeEval(

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -515,7 +515,10 @@ function appendCompileAndEvalInput(options: {
     // for example to prevent `2\n+ 2` from producing 4.
     // This is safe since the output will not change since we can only get here with successful inputs,
     // and adding a semicolon to the end of a successful input won't ever change the output.
-    state.input = `${state.input.slice(0, -1)};\n`;
+    state.input = state.input.replace(/([^\n\s])([\n\s]*)$/, (all, lastChar, whitespace) => {
+      if(lastChar !== ';') return `${lastChar};${whitespace}`;
+      return all;
+    });
   }
 
   let commands: Array<{ mustAwait?: true; execCommand: () => any }> = [];

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -221,8 +221,8 @@ export function createRepl(options: CreateReplOptions = {}) {
     // and adding a semicolon to the end of a successful input won't ever change the output.
     // We check to make sure the previous line ends in a newline just in case, even though it should
     // always be the case.
-    if (/\n$/.test(state.input)) {
-      state.input = state.input.slice(0, state.input.length - 1) + ';\n';
+    if (state.input.charAt(state.input.length - 1) === '\n') {
+      state.input = `${state.input.slice(0, -1)};\n`;
     }
     return result;
   }
@@ -595,15 +595,6 @@ function appendToEvalState(state: EvalState, input: string) {
   const undoVersion = state.version;
   const undoOutput = state.output;
   const undoLines = state.lines;
-
-  // Handle ASI issues with TypeScript re-evaluation.
-  if (
-    undoInput.charAt(undoInput.length - 1) === '\n' &&
-    /^\s*[\/\[(`-]/.test(input) &&
-    !/;\s*$/.test(undoInput)
-  ) {
-    state.input = `${state.input.slice(0, -1)};\n`;
-  }
 
   state.input += input;
   state.lines += lineCount(input);

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -515,10 +515,13 @@ function appendCompileAndEvalInput(options: {
     // for example to prevent `2\n+ 2` from producing 4.
     // This is safe since the output will not change since we can only get here with successful inputs,
     // and adding a semicolon to the end of a successful input won't ever change the output.
-    state.input = state.input.replace(/([^\n\s])([\n\s]*)$/, (all, lastChar, whitespace) => {
-      if(lastChar !== ';') return `${lastChar};${whitespace}`;
-      return all;
-    });
+    state.input = state.input.replace(
+      /([^\n\s])([\n\s]*)$/,
+      (all, lastChar, whitespace) => {
+        if (lastChar !== ';') return `${lastChar};${whitespace}`;
+        return all;
+      }
+    );
   }
 
   let commands: Array<{ mustAwait?: true; execCommand: () => any }> = [];

--- a/src/test/repl/repl.spec.ts
+++ b/src/test/repl/repl.spec.ts
@@ -304,6 +304,8 @@ test.suite(
         * 7\n.break
         100
         / 2\n.break
+        5
+        ** 2\n.break
         console.log('done!')
         `,
         { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
@@ -312,6 +314,7 @@ test.suite(
       expect(stdout).not.toContain('4');
       expect(stdout).not.toContain('21');
       expect(stdout).not.toContain('50');
+      expect(stdout).not.toContain('25');
       expect(stdout).toContain('3');
       expect(stdout).toContain('-3');
     });

--- a/src/test/repl/repl.spec.ts
+++ b/src/test/repl/repl.spec.ts
@@ -292,11 +292,12 @@ test.suite(
 test.suite(
   'REPL inputs are syntactically independent of each other',
   (test) => {
-
     // Serial because it's timing-sensitive
-    test.serial('arithmetic operators are independent of previous values', async (t) => {
-      const { stdout, stderr } = await t.context.executeInRepl(
-        `9
+    test.serial(
+      'arithmetic operators are independent of previous values',
+      async (t) => {
+        const { stdout, stderr } = await t.context.executeInRepl(
+          `9
         + 3
         7
         - 3
@@ -308,56 +309,66 @@ test.suite(
         ** 2\n.break
         console.log('done!')
         `,
-        { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
-      );
-      expect(stdout).not.toContain('12');
-      expect(stdout).not.toContain('4');
-      expect(stdout).not.toContain('21');
-      expect(stdout).not.toContain('50');
-      expect(stdout).not.toContain('25');
-      expect(stdout).toContain('3');
-      expect(stdout).toContain('-3');
-    });
+          { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
+        );
+        expect(stdout).not.toContain('12');
+        expect(stdout).not.toContain('4');
+        expect(stdout).not.toContain('21');
+        expect(stdout).not.toContain('50');
+        expect(stdout).not.toContain('25');
+        expect(stdout).toContain('3');
+        expect(stdout).toContain('-3');
+      }
+    );
 
     // Serial because it's timing-sensitive
-    test.serial('automatically inserted semicolons do not appear in error messages at the end', async (t) => {
-      const { stdout, stderr } = await t.context.executeInRepl(
-        `(
+    test.serial(
+      'automatically inserted semicolons do not appear in error messages at the end',
+      async (t) => {
+        const { stdout, stderr } = await t.context.executeInRepl(
+          `(
           a
           console.log('done!')`,
-        { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
-      );
-      expect(stderr).toContain("error TS1005: ')' expected.");
-      expect(stderr).not.toContain(';');
-    });
+          { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
+        );
+        expect(stderr).toContain("error TS1005: ')' expected.");
+        expect(stderr).not.toContain(';');
+      }
+    );
 
     // Serial because it's timing-sensitive
-    test.serial('automatically inserted semicolons do not appear in error messages at the start', async (t) => {
-      const { stdout, stderr } = await t.context.executeInRepl(
-        `)
+    test.serial(
+      'automatically inserted semicolons do not appear in error messages at the start',
+      async (t) => {
+        const { stdout, stderr } = await t.context.executeInRepl(
+          `)
         console.log('done!')`,
-        { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
-      );
-      expect(stderr).toContain(
-        'error TS1128: Declaration or statement expected.'
-      );
-      expect(stderr).toContain(')');
-      expect(stderr).not.toContain(';');
-    });
+          { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
+        );
+        expect(stderr).toContain(
+          'error TS1128: Declaration or statement expected.'
+        );
+        expect(stderr).toContain(')');
+        expect(stderr).not.toContain(';');
+      }
+    );
 
     // Serial because it's timing-sensitive
-    test.serial('automatically inserted semicolons do not break function calls', async (t) => {
-      const { stdout, stderr } = await t.context.executeInRepl(
-        `function foo(a: number) {
+    test.serial(
+      'automatically inserted semicolons do not break function calls',
+      async (t) => {
+        const { stdout, stderr } = await t.context.executeInRepl(
+          `function foo(a: number) {
           return a + 1;
       }
       foo(
         1
       )`,
-        { registerHooks: true, waitPattern: '2\n>' }
-      );
-      expect(stderr).toBe('');
-      expect(stdout).toContain('2');
-    });
+          { registerHooks: true, waitPattern: '2\n>' }
+        );
+        expect(stderr).toBe('');
+        expect(stdout).toContain('2');
+      }
+    );
   }
 );

--- a/src/test/repl/repl.spec.ts
+++ b/src/test/repl/repl.spec.ts
@@ -288,3 +288,73 @@ test.suite(
     });
   }
 );
+
+test.suite(
+  'REPL inputs are syntactically independent of each other',
+  (test) => {
+
+    // Serial because it's timing-sensitive
+    test.serial('arithmetic operators are independent of previous values', async (t) => {
+      const { stdout, stderr } = await t.context.executeInRepl(
+        `9
+        + 3
+        7
+        - 3
+        3
+        * 7\n.break
+        100
+        / 2\n.break
+        console.log('done!')
+        `,
+        { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
+      );
+      expect(stdout).not.toContain('12');
+      expect(stdout).not.toContain('4');
+      expect(stdout).not.toContain('21');
+      expect(stdout).not.toContain('50');
+      expect(stdout).toContain('3');
+      expect(stdout).toContain('-3');
+    });
+
+    // Serial because it's timing-sensitive
+    test.serial('automatically inserted semicolons do not appear in error messages at the end', async (t) => {
+      const { stdout, stderr } = await t.context.executeInRepl(
+        `(
+          a
+          console.log('done!')`,
+        { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
+      );
+      expect(stderr).toContain("error TS1005: ')' expected.");
+      expect(stderr).not.toContain(';');
+    });
+
+    // Serial because it's timing-sensitive
+    test.serial('automatically inserted semicolons do not appear in error messages at the start', async (t) => {
+      const { stdout, stderr } = await t.context.executeInRepl(
+        `)
+        console.log('done!')`,
+        { registerHooks: true, waitPattern: 'done!\nundefined\n>' }
+      );
+      expect(stderr).toContain(
+        'error TS1128: Declaration or statement expected.'
+      );
+      expect(stderr).toContain(')');
+      expect(stderr).not.toContain(';');
+    });
+
+    // Serial because it's timing-sensitive
+    test.serial('automatically inserted semicolons do not break function calls', async (t) => {
+      const { stdout, stderr } = await t.context.executeInRepl(
+        `function foo(a: number) {
+          return a + 1;
+      }
+      foo(
+        1
+      )`,
+        { registerHooks: true, waitPattern: '2\n>' }
+      );
+      expect(stderr).toBe('');
+      expect(stdout).toContain('2');
+    });
+  }
+);


### PR DESCRIPTION
Fixes #1363.

Multiline inputs aren't an issue since multiline inputs are passed into `evalCodeInternal` in their entirety.