### PR TITLE
fix: Filter empty strings out of list options

### DIFF
--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -602,6 +602,21 @@ test.suite('ts-node', (test) => {
         ]);
       });
 
+      test('should ignore empty strings in the array options', async () => {
+        const { err, stdout } = await exec(
+          `${BIN_EXEC} tsconfig-options/log-options1.js`,
+          {
+            env: {
+              ...process.env,
+              TS_NODE_IGNORE: '',
+            },
+          }
+        );
+        expect(err).toBe(null);
+        const { options } = JSON.parse(stdout);
+        expect(options.ignore).toEqual([]);
+      });
+
       test('should have flags override / merge with `tsconfig.json`', async () => {
         const { err, stdout } = await exec(
           `${BIN_EXEC} --skip-ignore --compiler-options "{\\"types\\":[\\"flags-types\\"]}" --require ./tsconfig-options/required2.js tsconfig-options/log-options2.js`

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,7 +43,9 @@ export function assign<T extends object>(
  * @internal
  */
 export function split(value: string | undefined) {
-  return typeof value === 'string' ? value.split(/ *, */g) : undefined;
+  return typeof value === 'string'
+    ? value.split(/ *, */g).filter((v) => v !== '')
+    : undefined;
 }
 
 /**


### PR DESCRIPTION
Filters out empty strings from `split` list env variables, allowing `TS_NODE_IGNORE=  <...>` to be treated as an empty array.

Closes #1301