### PR TITLE
Invoke TS compiler before starting REPL prompt

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -329,6 +329,11 @@ export function createRepl(options: CreateReplOptions = {}) {
       }
     }
 
+    // In case the typescript compiler hasn't compiled anything yet,
+    // make it run though compilation at least one time before
+    // the REPL starts for a snappier user experience on startup.
+    service?.compile('', state.path);
+
     const repl = nodeReplStart({
       prompt: '> ',
       input: replService.stdin,


### PR DESCRIPTION
Following up discussion from #1491

Gets the typescript compiler warmed up by invoking it before the REPL prompt appears. Slightly increases time to prompt but improves first tab completion/input performance.