### PR TITLE
add Target ES2021 mapping in transpilers/swc

### DIFF
--- a/src/test/transpilers.spec.ts
+++ b/src/test/transpilers.spec.ts
@@ -3,24 +3,25 @@
 // Should consolidate them here.
 
 import { context } from './testlib';
-import {
-  contextTsNodeUnderTest,
-  testsDirRequire,
-} from './helpers';
+import { contextTsNodeUnderTest, testsDirRequire } from './helpers';
 import * as expect from 'expect';
 
 const test = context(contextTsNodeUnderTest);
 
 test.suite('swc', (test) => {
   test('verify that TS->SWC target mappings suppport all possible values from both TS and SWC', async (t) => {
-    const swcTranspiler = testsDirRequire('ts-node/transpilers/swc-experimental') as typeof import('../transpilers/swc');
+    const swcTranspiler = testsDirRequire(
+      'ts-node/transpilers/swc-experimental'
+    ) as typeof import('../transpilers/swc');
 
     // Detect when mapping is missing any ts.ScriptTargets
     const ts = testsDirRequire('typescript') as typeof import('typescript');
-    for(const key of Object.keys(ts.ScriptTarget)) {
-      if(/^\d+$/.test(key)) continue;
-      if(key === 'JSON') continue;
-      expect(swcTranspiler.targetMapping.has(ts.ScriptTarget[key as any] as any)).toBe(true);
+    for (const key of Object.keys(ts.ScriptTarget)) {
+      if (/^\d+$/.test(key)) continue;
+      if (key === 'JSON') continue;
+      expect(
+        swcTranspiler.targetMapping.has(ts.ScriptTarget[key as any] as any)
+      ).toBe(true);
     }
 
     // Detect when mapping is missing any swc targets
@@ -28,8 +29,8 @@ test.suite('swc', (test) => {
     const swc = testsDirRequire('@swc/core');
     let msg: string | undefined = undefined;
     try {
-      swc.transformSync('', {jsc: {target: 'invalid'}});
-    } catch(e) {
+      swc.transformSync('', { jsc: { target: 'invalid' } });
+    } catch (e) {
       msg = (e as Error).message;
     }
     expect(msg).toBeDefined();
@@ -39,7 +40,7 @@ test.suite('swc', (test) => {
     expect(match).toBeDefined();
     const targets = match![1].split(', ').map((v: string) => v.slice(1, -1));
 
-    for(const target of targets) {
+    for (const target of targets) {
       expect([...swcTranspiler.targetMapping.values()]).toContain(target);
     }
   });

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -61,11 +61,13 @@ export function create(createOptions: SwcTranspilerOptions): Transpiler {
     // Perhaps project has an older version of swc.
     // TODO cache the results of this; slightly faster
     let swcTargetIndex = swcTargets.indexOf(swcTarget);
-    for(; swcTargetIndex >= 0; swcTargetIndex--) {
+    for (; swcTargetIndex >= 0; swcTargetIndex--) {
       try {
-        swcInstance.transformSync('', {jsc: {target: swcTargets[swcTargetIndex]}});
+        swcInstance.transformSync('', {
+          jsc: { target: swcTargets[swcTargetIndex] },
+        });
         break;
-      } catch(e) {}
+      } catch (e) {}
     }
     swcTarget = swcTargets[swcTargetIndex];
     const keepClassNames = target! >= /* ts.ScriptTarget.ES2016 */ 3;
@@ -148,7 +150,17 @@ type SwcTarget = typeof swcTargets[number];
  * @internal
  * We use this list to downgrade to a prior target when we probe swc to detect if it supports a particular target
  */
-const swcTargets = ['es3', 'es5', 'es2015', 'es2016', 'es2017', 'es2018', 'es2019', 'es2020', 'es2021'] as const;
+const swcTargets = [
+  'es3',
+  'es5',
+  'es2015',
+  'es2016',
+  'es2017',
+  'es2018',
+  'es2019',
+  'es2020',
+  'es2021',
+] as const;
 
 const ModuleKind = {
   None: 0,


### PR DESCRIPTION
I was getting error: `jsc.target should be es5 or upper to use getter / setter` 
and after investigation I've isolated issue and here is the "fix"