### PR TITLE
Add swc target "es2022"

### DIFF
--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -143,7 +143,7 @@ targetMapping.set(/* ts.ScriptTarget.ES2018 */ 5, 'es2018');
 targetMapping.set(/* ts.ScriptTarget.ES2019 */ 6, 'es2019');
 targetMapping.set(/* ts.ScriptTarget.ES2020 */ 7, 'es2020');
 targetMapping.set(/* ts.ScriptTarget.ES2021 */ 8, 'es2021');
-targetMapping.set(/* ts.ScriptTarget.ESNext */ 99, 'es2021');
+targetMapping.set(/* ts.ScriptTarget.ESNext */ 99, 'es2022');
 
 type SwcTarget = typeof swcTargets[number];
 /**
@@ -160,6 +160,7 @@ const swcTargets = [
   'es2019',
   'es2020',
   'es2021',
+  'es2022'
 ] as const;
 
 const ModuleKind = {

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -160,7 +160,7 @@ const swcTargets = [
   'es2019',
   'es2020',
   'es2021',
-  'es2022'
+  'es2022',
 ] as const;
 
 const ModuleKind = {


### PR DESCRIPTION
This was caught by our new automated tests.

swc added target es2022.  TS target options only go up to 2021, so the mappings are a bit non-ideal for the moment:

TS esnext -> swc es2022
TS es2021 -> swc es2021

Typically, I have understood TS's esnext to be an alias for the highest non-next target, so es2021 is an alias for esnext.  We are slightly breaking that rule with swc, saying that those two values map to different swc targets.