### PR TITLE
allow disabling "use strict" emit in SWC when you reeeally want to

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -510,27 +510,18 @@
       }
     },
     "@napi-rs/triples": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.2.tgz",
-      "integrity": "sha512-EL3SiX43m9poFSnhDx4d4fn9SSaqyO2rHsCNhETi9bWPmjXK3uPJ0QpPFtx39FEdHcz1vJmsiW41kqc0AgvtzQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/triples/-/triples-1.0.3.tgz",
+      "integrity": "sha512-jDJTpta+P4p1NZTFVLHJ/TLFVYVcOqv6l8xwOeBKNPMgY/zDYH/YH7SJbvrr/h1RcS9GzbPcLKGzpuK9cV56UA==",
       "dev": true
     },
     "@node-rs/helper": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.1.0.tgz",
-      "integrity": "sha512-r43YnnrY5JNzDuXJdW3sBJrKzvejvFmFWbiItUEoBJsaPzOIWFMhXB7i5j4c9EMXcFfxveF4l7hT+rLmwtjrVQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@node-rs/helper/-/helper-1.2.1.tgz",
+      "integrity": "sha512-R5wEmm8nbuQU0YGGmYVjEc0OHtYsuXdpRG+Ut/3wZ9XAvQWyThN08bTh2cBJgoZxHQUPtvRfeQuxcAgLuiBISg==",
       "dev": true,
       "requires": {
-        "@napi-rs/triples": "^1.0.2",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
-          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
-          "dev": true
-        }
+        "@napi-rs/triples": "^1.0.3"
       }
     },
     "@nodelib/fs.scandir": {
@@ -709,83 +700,107 @@
       "dev": true
     },
     "@swc/core": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.58.tgz",
-      "integrity": "sha512-u/vaon34x4ISDDdgZLaxacPB4Ly8SqqmFkBKPp2VtUDbD12VqKzb6EoLDC3A5EULFQDgIdIMHuVlBB+mc8dq0w==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.106.tgz",
+      "integrity": "sha512-9uw8gqU+lsk7KROAcSNhsrnBgNiC5H4MIaps5LlnnEevJmKu/o1ws22tXc2qjJg+F4/V1ynUbh8E0rYlmo1XGw==",
       "dev": true,
       "requires": {
         "@node-rs/helper": "^1.0.0",
-        "@swc/core-android-arm64": "^1.2.58",
-        "@swc/core-darwin-arm64": "^1.2.58",
-        "@swc/core-darwin-x64": "^1.2.58",
-        "@swc/core-linux-arm-gnueabihf": "^1.2.58",
-        "@swc/core-linux-arm64-gnu": "^1.2.58",
-        "@swc/core-linux-x64-gnu": "^1.2.58",
-        "@swc/core-linux-x64-musl": "^1.2.58",
-        "@swc/core-win32-ia32-msvc": "^1.2.58",
-        "@swc/core-win32-x64-msvc": "^1.2.58"
+        "@swc/core-android-arm64": "^1.2.106",
+        "@swc/core-darwin-arm64": "^1.2.106",
+        "@swc/core-darwin-x64": "^1.2.106",
+        "@swc/core-freebsd-x64": "^1.2.106",
+        "@swc/core-linux-arm-gnueabihf": "^1.2.106",
+        "@swc/core-linux-arm64-gnu": "^1.2.106",
+        "@swc/core-linux-arm64-musl": "^1.2.106",
+        "@swc/core-linux-x64-gnu": "^1.2.106",
+        "@swc/core-linux-x64-musl": "^1.2.106",
+        "@swc/core-win32-arm64-msvc": "^1.2.106",
+        "@swc/core-win32-ia32-msvc": "^1.2.106",
+        "@swc/core-win32-x64-msvc": "^1.2.106"
       }
     },
     "@swc/core-android-arm64": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.58.tgz",
-      "integrity": "sha512-eSNNt/KiAbseOZ/lbaHnXClWOOeEPBRJBjxIBDX6U4oXaHLBCwgwU+qhWziVV4Lq6gX0zqcw6JY7Pxz9r2Pxzw==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.106.tgz",
+      "integrity": "sha512-F5T6kP3yV9S0/oXyco305QaAyE6rLNsNSdR0QI4CtACwKadiPwTOptwNIDCiTNLNgWlWLQmIRkPpxg+G4doT6Q==",
       "dev": true,
       "optional": true
     },
     "@swc/core-darwin-arm64": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.58.tgz",
-      "integrity": "sha512-PHZm9kYi4KjWgac86fhr1238elI7M1K8Zh634eDCJCZbU7LHWUWOyeTpT9G8dxOuAUTOUZDaCHNW/+63N5XWPA==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.106.tgz",
+      "integrity": "sha512-bgKzzYLFnc+mv2mDS/DLwzBvx5DCC9ZCKYY46b4dAnBfasr+SMHj+v/WI84HtilbjLBMUfYZ2hgYKls3CebIIQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-darwin-x64": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.58.tgz",
-      "integrity": "sha512-jKJNNxBbt/ckp49QUP28P+YEGDS3baruCBRbVkgJQY5Nj5GKw5kay6prVf6ajhoegmtjLr+1p3By7S5XOgIc8g==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.106.tgz",
+      "integrity": "sha512-I5Uhit5RqbXaMIV2+v9jL+MIQeR3lT1DqVwzxZs1bTARclAheFZQpTmg+h6QmichjCiUT74SXQb6Apc/vqYKog==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-freebsd-x64": {
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.106.tgz",
+      "integrity": "sha512-ZSK3vgzbA2Pkpw2LgHlAkUdx4okIpdXXTbLXuc5jkZMw1KhRWpeQaDlwbrN7XVynAYjkj2qgGQ7wv1tD43vQig==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm-gnueabihf": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.58.tgz",
-      "integrity": "sha512-dnZcurOjTEr2IkSdWakyoVlE6ay3QQSSTv/9IsBH3eI7CI2+W8m9AtQ+KyN5BKPBSK5NjswF59xA3gocbsUpng==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.106.tgz",
+      "integrity": "sha512-WZh6XV8cQ9Fh3IQNX9z87Tv68+sLtfnT51ghMQxceRhfvc5gIaYW+PCppezDDdlPJnWXhybGWNPAl5SHppWb2g==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-arm64-gnu": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.58.tgz",
-      "integrity": "sha512-lSOd73EqFLx0I0f9UJq2wbwjQc+tbXbLznJp89tEZeLOljuMJkF3O22l2Nv6Vet6NBPbTQYiKy6ouibFvOqMag==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.106.tgz",
+      "integrity": "sha512-OSI9VUWPsRrCbUlRQ4KdYqdwV63VYBC5ahSNq+72DXhtRwVbLSFuF7MNsnXgUSMHidxbc0No3/bPPamshqHdsQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.106.tgz",
+      "integrity": "sha512-de8AAUOP8D2/tZIpQ399xw+pGGKlR1+l5Jmy4lW7ixarEI4xKkBSF4bS9eXtC1jckmenzrLPiK/5sSbQSf6BWQ==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-gnu": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.58.tgz",
-      "integrity": "sha512-bDU2LiURs4MKXWNNUKxVU1KKCO6lp1ILszkLPYuRAHbbQCtoQUe5JCbFlCqniFOxZOm2NBtZF4a+z5bGFpb0QA==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.106.tgz",
+      "integrity": "sha512-QzFC7+lBSuVBmX5tS2pdM+74voiJcGgIMJ+x9pcjUu3GkDl3ow6WC6ta2WUzlgGopCGNp6IdZaFemKRzjLr3lw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-linux-x64-musl": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.58.tgz",
-      "integrity": "sha512-wdF8nHrlMI4PUL13PQFo4BMfCr9HL3kNWftiA8i+mJhfp8Z2xfyarOnVkeXmYmQYGPoqSDCsskui6n5PvBLePw==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.106.tgz",
+      "integrity": "sha512-QZ1gFqNiCJefkNMihbmYc7nr5stERyjoQpWgAIN6dzrgMUzRHXHGDRl/p1qsXW2VKos+okSdLwPFEmRT94H+1A==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.106.tgz",
+      "integrity": "sha512-MbuQwk+s43bfBNnAZTKnoQlfo4UPSOsy6t9F15yU4P3rVUuFtcxdZg6CpDnUqNPbojILXujp8z4SSigRYh5cgg==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-ia32-msvc": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.58.tgz",
-      "integrity": "sha512-Qrox0Kz3KQSYnMwAH55DYXzOG+L0PPYQHaQnJCh5rywKDUx2n/Ar5zKkVkEhRf0ehPgKajt0h2BYHsTpqNA9/w==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.106.tgz",
+      "integrity": "sha512-BFxWpcPxsG2LLQZ+8K8ma45rbTckjpPbnvOOhybQ0hEhLgoVzMVPp3RIUGmC+RMZe6DkGSaEQf/Rjn2cbMdQhw==",
       "dev": true,
       "optional": true
     },
     "@swc/core-win32-x64-msvc": {
-      "version": "1.2.58",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.58.tgz",
-      "integrity": "sha512-HPmxovhC7DbNcXLJe5nUmo+4o6Ea2d7oFdli3IvTgDri0IynQaRlfVWIuNnZmEsN7Gl1kW7PUK5WZXPUosMn8A==",
+      "version": "1.2.106",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.106.tgz",
+      "integrity": "sha512-Emn5akqApGXzPsA7ntSXEohL0AH0WjQMHy6mT3MS9Yil42yTJ96dJGf68ejKVptxwg7Iz798mT+J9r1JbAFBgg==",
       "dev": true,
       "optional": true
     },

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -96,7 +96,9 @@ export function create(createOptions: SwcTranspilerOptions): Transpiler {
       // if `alwaysStrict` is disabled, remembering that `strict` defaults `alwaysStrict` to true
       (alwaysStrict === false || (alwaysStrict !== true && strict !== true)) &&
       // if noImplicitUseStrict is enabled
-      noImplicitUseStrict === true ? false : true;
+      noImplicitUseStrict === true
+        ? false
+        : true;
     return {
       sourceMaps: sourceMap,
       // isModule: true,


### PR DESCRIPTION
Fixes #1531 

Tell swc to emit "use strict" in all cases *except* when both `alwaysStrict` is disabled and `noImplicitUseStrict` is enabled.

---

`tsc`, by default, will add `"use strict"` whenever you use any sort of import or export.  Additionally, if `strict: true` is configured, it will *always* emit `"use strict"`.

I expect that *most* node scripts, even standalone ones, will have at least one import, for example `import {} from 'fs';`  TS is bending over backwards to allow scripts with _zero_ imports or exports to run in non-strict mode.  I suspect this behavior only exists for backwards compatibility, and users generally want "use strict" enabled when working with node.

swc is not as nuanced as TS.  We can either tell it to always emit use strict, or never emit.

Given this limitation of swc, I'm going to pragmatically assume that all node scripts have an import or export, and set swc's options to emit `"use strict"`.

If a user *really really* needs to avoid strict mode, they will likely have `alwaysStrict: false, noImplicitUseStrict: true`.  We can detect this and tell swc not to emit `"use strict"`