### PR TITLE
Passing arguments in shebang on Linux (env -S)

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,11 +162,17 @@ console.log("Hello, world!")
 ```
 
 Passing CLI arguments via shebang is allowed on Mac but not Linux.  For example, the following will fail on Linux:
+### Passing CLI arguments via shebang
 
-    #!/usr/bin/env ts-node --files
-    // This shebang is not portable.  It only works on Mac
+- On Mac:
 
-Instead, specify all ts-node options in your `tsconfig.json`.
+      #!/usr/bin/env ts-node --files
+
+- On Linux:
+
+      #!/usr/bin/env -S ts-node --files
+
+  The `-S` option for `env` processes and splits what comes after it into separate arguments; and is used to pass multiple arguments on shebang lines.
 
 ## Programmatic
 

--- a/README.md
+++ b/README.md
@@ -162,17 +162,11 @@ console.log("Hello, world!")
 ```
 
 Passing CLI arguments via shebang is allowed on Mac but not Linux.  For example, the following will fail on Linux:
-### Passing CLI arguments via shebang
 
-- On Mac:
+    #!/usr/bin/env ts-node --files
+    // This shebang is not portable.  It only works on Mac
 
-      #!/usr/bin/env ts-node --files
-
-- On Linux:
-
-      #!/usr/bin/env -S ts-node --files
-
-  The `-S` option for `env` processes and splits what comes after it into separate arguments; and is used to pass multiple arguments on shebang lines.
+Instead, specify all ts-node options in your `tsconfig.json`.
 
 ## Programmatic
 

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -35,14 +35,27 @@ ts-node-cwd script.ts
 console.log("Hello, world!")
 ```
 
-Passing CLI arguments via shebang is allowed on Mac but not Linux.  For example, the following will fail on Linux:
+Passing options via shebang requires the [`env -S` flag](https://manpages.debian.org/bullseye/coreutils/env.1.en.html#S), which is not available on old versions of `env`.
 
-```
-#!/usr/bin/env ts-node --files
-// This shebang is not portable.  It only works on Mac
+```typescript
+#!/usr/bin/env -S ts-node --files
+// This shebang works on Mac and Linux with newer versions of env
+// Technically, Mac allows omitting `-S`, but Linux requires it
 ```
 
-Instead, specify all ts-node options in your `tsconfig.json`.
+To write scripts with maximum portability, [specify all options in your `tsconfig.json`](./configuration#via-tsconfigjson-recommended) and omit them from the shebang.
+
+```typescript
+#!/usr/bin/env ts-node
+// This shebang works everywhere
+```
+
+To test your version of `env` for compatibility:
+
+```shell
+# Note that these unusual quotes are necessary
+/usr/bin/env --debug '-S echo foo bar'
+```
 
 ## Programmatic
 

--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -35,7 +35,7 @@ ts-node-cwd script.ts
 console.log("Hello, world!")
 ```
 
-Passing options via shebang requires the [`env -S` flag](https://manpages.debian.org/bullseye/coreutils/env.1.en.html#S), which is not available on old versions of `env`.
+Passing options via shebang requires the [`env -S` flag](https://manpages.debian.org/bullseye/coreutils/env.1.en.html#S), which is available on recent versions of `env`. ([compatibility](https://github.com/TypeStrong/ts-node/pull/1448#issuecomment-913895766))
 
 ```typescript
 #!/usr/bin/env -S ts-node --files


### PR DESCRIPTION
EDIT from @cspotcode: Closes #1448, also give credit to @chee in release notes

---

It is possible to pass arguments into commands in the shebang (at least on GNU/Linux) using the `-S` option for env [0][1].

The README currently says that it's not possible to do this on Linux, which is wrong.

[0] [env(1) manpage in Debian Bullseye](https://manpages.debian.org/bullseye/coreutils/env.1.en.html#S).
[1] [GNU coreutils env documentation](https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html).