### PR TITLE
Fix failing test broken by node nightly

### DIFF
--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1146,7 +1146,7 @@ test.suite('ts-node', (test) => {
         expect(err).not.toBe(null);
         // expect error from node's default resolver
         expect(stderr).toMatch(
-          /Error \[ERR_UNSUPPORTED_ESM_URL_SCHEME\]:.*(?:\n.*){0,1}\n *at defaultResolve/
+          /Error \[ERR_UNSUPPORTED_ESM_URL_SCHEME\]:.*(?:\n.*){0,2}\n *at defaultResolve/
         );
       });
 


### PR DESCRIPTION
Test assertion expects a slightly different stack trace than is raised by node nightly.