### PR TITLE
Stop downleveling async functions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "$schema": "./tsconfig.schemastore-schema.json",
   "compilerOptions": {
-    "target": "es2015",
-    "lib": ["es2015", "dom"],
+    // `target` and `lib` match @tsconfig/bases for node12, since that's the oldest node LTS, so it's the oldest node we support
+    "target": "es2019",
+    "lib": ["es2019", "es2020.promise", "es2020.bigint", "es2020.string", "dom"],
     "rootDir": "src",
     "outDir": "dist",
     "module": "commonjs",


### PR DESCRIPTION
Makes assertion failures in tests log nicer. (no more saying that every error is thrown from a tslib helper)

Oldest node we support is node12, so as long as it works there, we're good.