### PR TITLE
docs: add option to display the last update time

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -124,6 +124,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
+          showLastUpdateTime: true,
           editUrl:
             'https://github.com/TypeStrong/ts-node/edit/docs/website/',
         },


### PR DESCRIPTION
Prior this PR, there was no way to tell if we are reading a new version of the docs besides reading it entirely.

Now we'll get something like this:

![image](https://user-images.githubusercontent.com/13461315/148601214-a369c88c-bc0f-4730-9170-ecb8f20f9d8d.png)