### PR TITLE
Fix #1389: Make `--showConfig` `moduleTypes` log correct, relative paths same as include

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -328,18 +328,25 @@ Options:
       process.exit(1);
     }
     let moduleTypes = undefined;
-    if(service.options.moduleTypes) {
+    if (service.options.moduleTypes) {
       // Assumption: this codepath requires CLI invocation, so moduleTypes must have come from a tsconfig, not API.
       const showRelativeTo = dirname(service.configFilePath!);
       moduleTypes = {} as Record<string, string>;
-      for(const [key, value] of Object.entries(service.options.moduleTypes)) {
-        moduleTypes[relative(showRelativeTo, resolve(service.options.optionBasePaths?.moduleTypes!, key))] = value;
+      for (const [key, value] of Object.entries(service.options.moduleTypes)) {
+        moduleTypes[
+          relative(
+            showRelativeTo,
+            resolve(service.options.optionBasePaths?.moduleTypes!, key)
+          )
+        ] = value;
       }
     }
     const json = {
       ['ts-node']: {
         ...service.options,
-        require: service.options.require?.length ? service.options.require : undefined,
+        require: service.options.require?.length
+          ? service.options.require
+          : undefined,
         moduleTypes,
         optionBasePaths: undefined,
         compilerOptions: undefined,

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -323,7 +323,7 @@ Options:
     const ts = service.ts as any as TSInternal;
     if (typeof ts.convertToTSConfig !== 'function') {
       console.error(
-        'Error: --show-config requires a typescript versions >=3.2 that support --showConfig'
+        'Error: --showConfig requires a typescript versions >=3.2 that support --showConfig'
       );
       process.exit(1);
     }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { join, resolve, dirname, parse as parsePath } from 'path';
+import { join, resolve, dirname, parse as parsePath, relative } from 'path';
 import { inspect } from 'util';
 import Module = require('module');
 import arg = require('arg');
@@ -327,9 +327,20 @@ Options:
       );
       process.exit(1);
     }
+    let moduleTypes = undefined;
+    if(service.options.moduleTypes) {
+      // Assumption: this codepath requires CLI invocation, so moduleTypes must have come from a tsconfig, not API.
+      const showRelativeTo = dirname(service.configFilePath!);
+      moduleTypes = {} as Record<string, string>;
+      for(const [key, value] of Object.entries(service.options.moduleTypes)) {
+        moduleTypes[relative(showRelativeTo, resolve(service.options.optionBasePaths?.moduleTypes!, key))] = value;
+      }
+    }
     const json = {
       ['ts-node']: {
         ...service.options,
+        require: service.options.require?.length ? service.options.require : undefined,
+        moduleTypes,
         optionBasePaths: undefined,
         compilerOptions: undefined,
         project: service.configFilePath ?? service.options.project,

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -889,7 +889,7 @@ test.suite('ts-node', (test) => {
     });
 
     if (semver.gte(ts.version, '3.2.0')) {
-      test('--show-config should log resolved configuration', async (t) => {
+      test('--showConfig should log resolved configuration', async (t) => {
         function native(path: string) {
           return path.replace(/\/|\\/g, pathSep);
         }
@@ -908,7 +908,6 @@ test.suite('ts-node', (test) => {
                 cwd: native(`${ROOT_DIR}/tests`),
                 projectSearchDir: native(`${ROOT_DIR}/tests`),
                 project: native(`${ROOT_DIR}/tests/tsconfig.json`),
-                require: [],
               },
               compilerOptions: {
                 target: 'es6',

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -937,7 +937,7 @@ test.suite('ts-node', (test) => {
           `${CMD_TS_NODE_WITH_PROJECT_FLAG} --showConfig`
         );
         expect(err).not.toBe(null);
-        expect(stderr).toMatch('Error: --show-config requires');
+        expect(stderr).toMatch('Error: --showConfig requires');
       });
     }
 


### PR DESCRIPTION
Fixes #1389 
Also includes two unrelated tweaks:

`--showConfig` error message rewritten to say `--showConfig` instead of `--show-config`

If `require` array is empty, omit from `--showConfig` output