### PR TITLE
Fix #1323: `ts-node -vvv` also logs the paths to ts-node and typescript, so it's more obvious when you're accidentally using the global ones

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -312,10 +312,18 @@ Options:
   stdinStuff?.repl.setService(service);
 
   // Output project information.
-  if (version >= 2) {
+  if (version === 2) {
     console.log(`ts-node v${VERSION}`);
     console.log(`node ${process.version}`);
     console.log(`compiler v${service.ts.version}`);
+    process.exit(0);
+  }
+  if (version >= 3) {
+    console.log(`ts-node v${VERSION} ${dirname(__dirname)}`);
+    console.log(`node ${process.version}`);
+    console.log(
+      `compiler v${service.ts.version} ${service.compilerPath ?? ''}`
+    );
     process.exit(0);
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -477,6 +477,8 @@ export interface Service {
   /** @internal */
   [TS_NODE_SERVICE_BRAND]: true;
   ts: TSCommon;
+  /** @internal */
+  compilerPath: string;
   config: _ts.ParsedCommandLine;
   options: RegisterOptions;
   enabled(enabled?: boolean): boolean;
@@ -1340,6 +1342,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
   return {
     [TS_NODE_SERVICE_BRAND]: true,
     ts,
+    compilerPath: compiler,
     config,
     compile,
     getTypeInfo,


### PR DESCRIPTION
Fixes #1323

