### PR TITLE
Resolve #1613: transpiler / swc things to double-check

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -10,7 +10,7 @@ import {
 import type { TSInternal } from './ts-compiler-types';
 import { createTsInternals } from './ts-internals';
 import { getDefaultTsconfigJsonForNodeVersion } from './tsconfigs';
-import { assign, createRequire } from './util';
+import { assign, createProjectLocalResolveHelper } from './util';
 
 /**
  * TypeScript compiler option values required by `ts-node` which cannot be overridden.
@@ -172,9 +172,9 @@ export function readConfig(
     // Some options are relative to the config file, so must be converted to absolute paths here
     if (options.require) {
       // Modules are found relative to the tsconfig file, not the `dir` option
-      const tsconfigRelativeRequire = createRequire(configPath);
+      const tsconfigRelativeResolver = createProjectLocalResolveHelper(configPath);
       options.require = options.require.map((path: string) =>
-        tsconfigRelativeRequire.resolve(path)
+        tsconfigRelativeResolver(path, false)
       );
     }
     if (options.scopeDir) {
@@ -184,6 +184,12 @@ export function readConfig(
     // Downstream code uses the basePath; we do not do that here.
     if (options.moduleTypes) {
       optionBasePaths.moduleTypes = basePath;
+    }
+    if (options.transpiler != null) {
+      optionBasePaths.transpiler = basePath;
+    }
+    if (options.compiler != null) {
+      optionBasePaths.compiler = basePath;
     }
 
     assign(tsNodeOptionsFromTsconfig, options);

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -173,7 +173,7 @@ export function readConfig(
     if (options.require) {
       // Modules are found relative to the tsconfig file, not the `dir` option
       const tsconfigRelativeResolver =
-        createProjectLocalResolveHelper(configPath);
+        createProjectLocalResolveHelper(dirname(configPath));
       options.require = options.require.map((path: string) =>
         tsconfigRelativeResolver(path, false)
       );

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -172,8 +172,9 @@ export function readConfig(
     // Some options are relative to the config file, so must be converted to absolute paths here
     if (options.require) {
       // Modules are found relative to the tsconfig file, not the `dir` option
-      const tsconfigRelativeResolver =
-        createProjectLocalResolveHelper(dirname(configPath));
+      const tsconfigRelativeResolver = createProjectLocalResolveHelper(
+        dirname(configPath)
+      );
       options.require = options.require.map((path: string) =>
         tsconfigRelativeResolver(path, false)
       );

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -172,7 +172,8 @@ export function readConfig(
     // Some options are relative to the config file, so must be converted to absolute paths here
     if (options.require) {
       // Modules are found relative to the tsconfig file, not the `dir` option
-      const tsconfigRelativeResolver = createProjectLocalResolveHelper(configPath);
+      const tsconfigRelativeResolver =
+        createProjectLocalResolveHelper(configPath);
       options.require = options.require.map((path: string) =>
         tsconfigRelativeResolver(path, false)
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -596,7 +596,8 @@ export function create(rawOptions: CreateOptions = {}): Service {
    * be changed by the tsconfig, so we have to do this twice.
    */
   function loadCompiler(name: string | undefined, relativeToPath: string) {
-    const projectLocalResolveHelper = createProjectLocalResolveHelper(relativeToPath);
+    const projectLocalResolveHelper =
+      createProjectLocalResolveHelper(relativeToPath);
     const compiler = projectLocalResolveHelper(name || 'typescript', true);
     const ts: typeof _ts = attemptRequireWithV8CompileCache(require, compiler);
     return { compiler, ts, projectLocalResolveHelper };
@@ -605,7 +606,12 @@ export function create(rawOptions: CreateOptions = {}): Service {
   // Compute minimum options to read the config file.
   let { compiler, ts, projectLocalResolveHelper } = loadCompiler(
     compilerName,
-    getBasePathForProjectLocalDependencyResolution(undefined, rawOptions.projectSearchDir, rawOptions.project, cwd)
+    getBasePathForProjectLocalDependencyResolution(
+      undefined,
+      rawOptions.projectSearchDir,
+      rawOptions.project,
+      cwd
+    )
   );
 
   // Read config file and merge new options between env and CLI options.
@@ -627,8 +633,15 @@ export function create(rawOptions: CreateOptions = {}): Service {
   // Compiler is loaded relative to tsconfig.json, so tsconfig discovery may cause us to load a
   // different compiler than we did above, even if the name has not changed.
   if (configFilePath) {
-    ({ compiler, ts, projectLocalResolveHelper } = loadCompiler(options.compiler,
-      getBasePathForProjectLocalDependencyResolution(configFilePath, rawOptions.projectSearchDir, rawOptions.project, cwd)));
+    ({ compiler, ts, projectLocalResolveHelper } = loadCompiler(
+      options.compiler,
+      getBasePathForProjectLocalDependencyResolution(
+        configFilePath,
+        rawOptions.projectSearchDir,
+        rawOptions.project,
+        cwd
+      )
+    ));
   }
 
   // Experimental REPL await is not compatible targets lower than ES2018

--- a/src/index.ts
+++ b/src/index.ts
@@ -742,7 +742,6 @@ export function create(rawOptions: CreateOptions = {}): Service {
       typeof transpiler === 'string' ? transpiler : transpiler[0];
     const transpilerOptions =
       typeof transpiler === 'string' ? {} : transpiler[1] ?? {};
-    // TODO mimic fixed resolution logic from loadCompiler main (I forget what this comment is talking about)
     const transpilerPath = projectLocalResolveHelper(transpilerName, true);
     const transpilerFactory: TranspilerFactory = require(transpilerPath).create;
     customTranspiler = transpilerFactory({

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,11 @@ import {
   assign,
   attemptRequireWithV8CompileCache,
   cachedLookup,
+  createProjectLocalResolveHelper,
+  getBasePathForProjectLocalDependencyResolution,
   normalizeSlashes,
   parse,
+  ProjectLocalResolveHelper,
   split,
   yn,
 } from './util';
@@ -373,6 +376,8 @@ type ModuleTypes = Record<string, 'cjs' | 'esm' | 'package'>;
 /** @internal */
 export interface OptionBasePaths {
   moduleTypes?: string;
+  transpiler?: string;
+  compiler?: string;
 }
 
 /**
@@ -501,6 +506,8 @@ export interface Service {
   enableExperimentalEsmLoaderInterop(): void;
   /** @internal */
   transpileOnly: boolean;
+  /** @internal */
+  projectLocalResolveHelper: ProjectLocalResolveHelper;
 }
 
 /**
@@ -589,17 +596,16 @@ export function create(rawOptions: CreateOptions = {}): Service {
    * be changed by the tsconfig, so we have to do this twice.
    */
   function loadCompiler(name: string | undefined, relativeToPath: string) {
-    const compiler = require.resolve(name || 'typescript', {
-      paths: [relativeToPath, __dirname],
-    });
+    const projectLocalResolveHelper = createProjectLocalResolveHelper(relativeToPath);
+    const compiler = projectLocalResolveHelper(name || 'typescript', true);
     const ts: typeof _ts = attemptRequireWithV8CompileCache(require, compiler);
-    return { compiler, ts };
+    return { compiler, ts, projectLocalResolveHelper };
   }
 
   // Compute minimum options to read the config file.
-  let { compiler, ts } = loadCompiler(
+  let { compiler, ts, projectLocalResolveHelper } = loadCompiler(
     compilerName,
-    rawOptions.projectSearchDir ?? rawOptions.project ?? cwd
+    getBasePathForProjectLocalDependencyResolution(undefined, rawOptions.projectSearchDir, rawOptions.project, cwd)
   );
 
   // Read config file and merge new options between env and CLI options.
@@ -616,6 +622,14 @@ export function create(rawOptions: CreateOptions = {}): Service {
     ...(tsNodeOptionsFromTsconfig.require || []),
     ...(rawOptions.require || []),
   ];
+
+  // Re-load the compiler in case it has changed.
+  // Compiler is loaded relative to tsconfig.json, so tsconfig discovery may cause us to load a
+  // different compiler than we did above, even if the name has not changed.
+  if (configFilePath) {
+    ({ compiler, ts, projectLocalResolveHelper } = loadCompiler(options.compiler,
+      getBasePathForProjectLocalDependencyResolution(configFilePath, rawOptions.projectSearchDir, rawOptions.project, cwd)));
+  }
 
   // Experimental REPL await is not compatible targets lower than ES2018
   const targetSupportsTla = config.options.target! >= ts.ScriptTarget.ES2018;
@@ -636,13 +650,6 @@ export function create(rawOptions: CreateOptions = {}): Service {
     options.experimentalReplAwait !== false &&
     tsVersionSupportsTla &&
     targetSupportsTla;
-
-  // Re-load the compiler in case it has changed.
-  // Compiler is loaded relative to tsconfig.json, so tsconfig discovery may cause us to load a
-  // different compiler than we did above, even if the name has not changed.
-  if (configFilePath) {
-    ({ compiler, ts } = loadCompiler(options.compiler, configFilePath));
-  }
 
   // swc implies two other options
   // typeCheck option was implemented specifically to allow overriding tsconfig transpileOnly from the command-line
@@ -735,14 +742,11 @@ export function create(rawOptions: CreateOptions = {}): Service {
       typeof transpiler === 'string' ? transpiler : transpiler[0];
     const transpilerOptions =
       typeof transpiler === 'string' ? {} : transpiler[1] ?? {};
-    // TODO mimic fixed resolution logic from loadCompiler main
-    // TODO refactor into a more generic "resolve dep relative to project" helper
-    const transpilerPath = require.resolve(transpilerName, {
-      paths: [cwd, __dirname],
-    });
+    // TODO mimic fixed resolution logic from loadCompiler main (I forget what this comment is talking about)
+    const transpilerPath = projectLocalResolveHelper(transpilerName, true);
     const transpilerFactory: TranspilerFactory = require(transpilerPath).create;
     customTranspiler = transpilerFactory({
-      service: { options, config },
+      service: { options, config, projectLocalResolveHelper },
       ...transpilerOptions,
     });
   }
@@ -927,7 +931,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
         ts,
         cwd,
         config,
-        configFilePath,
+        projectLocalResolveHelper,
       });
       serviceHost.resolveModuleNames = resolveModuleNames;
       serviceHost.getResolvedModuleWithFailedLookupLocationsFromCache =
@@ -1078,10 +1082,10 @@ export function create(rawOptions: CreateOptions = {}): Service {
       } = createResolverFunctions({
         host,
         cwd,
-        configFilePath,
         config,
         ts,
         getCanonicalFileName,
+        projectLocalResolveHelper,
       });
       host.resolveModuleNames = resolveModuleNames;
       host.resolveTypeReferenceDirectives = resolveTypeReferenceDirectives;
@@ -1358,6 +1362,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
     installSourceMapSupport,
     enableExperimentalEsmLoaderInterop,
     transpileOnly,
+    projectLocalResolveHelper,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -265,6 +265,8 @@ export interface CreateOptions {
    * Transpile with swc instead of the TypeScript compiler, and skip typechecking.
    *
    * Equivalent to setting both `transpileOnly: true` and `transpiler: 'ts-node/transpilers/swc'`
+   *
+   * For complete instructions: https://typestrong.org/ts-node/docs/transpilers
    */
   swc?: boolean;
   /**

--- a/src/resolver-functions.ts
+++ b/src/resolver-functions.ts
@@ -137,7 +137,6 @@ export function createResolverFunctions(kwargs: {
           // Resolve @types/node relative to project first, then __dirname (copy logic from elsewhere / refactor into reusable function)
           let typesNodePackageJsonPath: string | undefined;
           try {
-            // TODO unify this require.resolve with generic fallback helper?
             typesNodePackageJsonPath = projectLocalResolveHelper('@types/node/package.json', true);
           } catch {} // gracefully do nothing when @types/node is not installed for any reason
           if (typesNodePackageJsonPath) {

--- a/src/resolver-functions.ts
+++ b/src/resolver-functions.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'path';
 import type * as _ts from 'typescript';
+import type { ProjectLocalResolveHelper } from './util';
 
 /**
  * @internal
@@ -11,9 +12,9 @@ export function createResolverFunctions(kwargs: {
   cwd: string;
   getCanonicalFileName: (filename: string) => string;
   config: _ts.ParsedCommandLine;
-  configFilePath: string | undefined;
+  projectLocalResolveHelper: ProjectLocalResolveHelper;
 }) {
-  const { host, ts, config, cwd, getCanonicalFileName, configFilePath } =
+  const { host, ts, config, cwd, getCanonicalFileName, projectLocalResolveHelper } =
     kwargs;
   const moduleResolutionCache = ts.createModuleResolutionCache(
     cwd,
@@ -136,12 +137,8 @@ export function createResolverFunctions(kwargs: {
           // Resolve @types/node relative to project first, then __dirname (copy logic from elsewhere / refactor into reusable function)
           let typesNodePackageJsonPath: string | undefined;
           try {
-            typesNodePackageJsonPath = require.resolve(
-              '@types/node/package.json',
-              {
-                paths: [configFilePath ?? cwd, __dirname],
-              }
-            );
+            // TODO unify this require.resolve with generic fallback helper?
+            typesNodePackageJsonPath = projectLocalResolveHelper('@types/node/package.json', true);
           } catch {} // gracefully do nothing when @types/node is not installed for any reason
           if (typesNodePackageJsonPath) {
             const typeRoots = [resolve(typesNodePackageJsonPath, '../..')];

--- a/src/resolver-functions.ts
+++ b/src/resolver-functions.ts
@@ -14,8 +14,14 @@ export function createResolverFunctions(kwargs: {
   config: _ts.ParsedCommandLine;
   projectLocalResolveHelper: ProjectLocalResolveHelper;
 }) {
-  const { host, ts, config, cwd, getCanonicalFileName, projectLocalResolveHelper } =
-    kwargs;
+  const {
+    host,
+    ts,
+    config,
+    cwd,
+    getCanonicalFileName,
+    projectLocalResolveHelper,
+  } = kwargs;
   const moduleResolutionCache = ts.createModuleResolutionCache(
     cwd,
     getCanonicalFileName,
@@ -137,7 +143,10 @@ export function createResolverFunctions(kwargs: {
           // Resolve @types/node relative to project first, then __dirname (copy logic from elsewhere / refactor into reusable function)
           let typesNodePackageJsonPath: string | undefined;
           try {
-            typesNodePackageJsonPath = projectLocalResolveHelper('@types/node/package.json', true);
+            typesNodePackageJsonPath = projectLocalResolveHelper(
+              '@types/node/package.json',
+              true
+            );
           } catch {} // gracefully do nothing when @types/node is not installed for any reason
           if (typesNodePackageJsonPath) {
             const typeRoots = [resolve(typesNodePackageJsonPath, '../..')];

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -15,23 +15,23 @@ export interface SwcTranspilerOptions extends CreateTranspilerOptions {
 export function create(createOptions: SwcTranspilerOptions): Transpiler {
   const {
     swc,
-    service: { config },
+    service: { config, projectLocalResolveHelper },
   } = createOptions;
 
   // Load swc compiler
   let swcInstance: typeof swcWasm;
   if (typeof swc === 'string') {
-    swcInstance = require(swc) as typeof swcWasm;
+    swcInstance = require(projectLocalResolveHelper(swc, true)) as typeof swcWasm;
   } else if (swc == null) {
     let swcResolved;
     try {
-      swcResolved = require.resolve('@swc/core');
+      swcResolved = projectLocalResolveHelper('@swc/core', true);
     } catch (e) {
       try {
-        swcResolved = require.resolve('@swc/wasm');
+        swcResolved = projectLocalResolveHelper('@swc/wasm', true);
       } catch (e) {
         throw new Error(
-          'swc compiler requires either @swc/core or @swc/wasm to be installed as dependencies'
+          'swc compiler requires either @swc/core or @swc/wasm to be installed as a dependency.  See https://typestrong.org/ts-node/docs/transpilers'
         );
       }
     }

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -21,7 +21,10 @@ export function create(createOptions: SwcTranspilerOptions): Transpiler {
   // Load swc compiler
   let swcInstance: typeof swcWasm;
   if (typeof swc === 'string') {
-    swcInstance = require(projectLocalResolveHelper(swc, true)) as typeof swcWasm;
+    swcInstance = require(projectLocalResolveHelper(
+      swc,
+      true
+    )) as typeof swcWasm;
   } else if (swc == null) {
     let swcResolved;
     try {

--- a/src/transpilers/types.ts
+++ b/src/transpilers/types.ts
@@ -16,7 +16,8 @@ export type TranspilerFactory = (
 ) => Transpiler;
 export interface CreateTranspilerOptions {
   // TODO this is confusing because its only a partial Service.  Rename?
-  service: Pick<Service, 'config' | 'options'>;
+  // Careful: must avoid stripInternal breakage by guarding with Extract<>
+  service: Pick<Service, Extract<'config' | 'options' | 'projectLocalResolveHelper', keyof Service>>;
 }
 export interface Transpiler {
   // TODOs

--- a/src/transpilers/types.ts
+++ b/src/transpilers/types.ts
@@ -17,7 +17,10 @@ export type TranspilerFactory = (
 export interface CreateTranspilerOptions {
   // TODO this is confusing because its only a partial Service.  Rename?
   // Careful: must avoid stripInternal breakage by guarding with Extract<>
-  service: Pick<Service, Extract<'config' | 'options' | 'projectLocalResolveHelper', keyof Service>>;
+  service: Pick<
+    Service,
+    Extract<'config' | 'options' | 'projectLocalResolveHelper', keyof Service>
+  >;
 }
 export interface Transpiler {
   // TODOs

--- a/src/util.ts
+++ b/src/util.ts
@@ -150,7 +150,7 @@ export function getBasePathForProjectLocalDependencyResolution(
   projectOption: string | undefined,
   cwdOption: string
 ) {
-  if(configFilePath != null) return dirname(configFilePath);
+  if (configFilePath != null) return dirname(configFilePath);
   return projectSearchDirOption ?? projectOption ?? cwdOption;
   // TODO technically breaks if projectOption is path to a file, not a directory,
   // and we attempt to resolve relative specifiers.  By the time we resolve relative specifiers,

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,7 @@ import {
 } from 'module';
 import type _createRequire from 'create-require';
 import * as ynModule from 'yn';
+import { dirname } from 'path';
 
 /** @internal */
 export const createRequire =
@@ -149,5 +150,9 @@ export function getBasePathForProjectLocalDependencyResolution(
   projectOption: string | undefined,
   cwdOption: string
 ) {
-  return configFilePath ?? projectSearchDirOption ?? projectOption ?? cwdOption;
+  if(configFilePath != null) return dirname(configFilePath);
+  return projectSearchDirOption ?? projectOption ?? cwdOption;
+  // TODO technically breaks if projectOption is path to a file, not a directory,
+  // and we attempt to resolve relative specifiers.  By the time we resolve relative specifiers,
+  // should have configFilePath, so not reach this codepath.
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -113,3 +113,29 @@ export function attemptRequireWithV8CompileCache(
     return requireFn(specifier);
   }
 }
+
+/**
+ * Helper to discover dependencies relative to a user's project, optionally
+ * falling back to relative to ts-node.  This supports global installations of
+ * ts-node, for example where someone does `#!/usr/bin/env -S ts-node --swc` and
+ * we need to fallback to a global install of @swc/core
+ * @internal
+ */
+export function createProjectLocalResolveHelper(localDirectory: string) {
+  return function projectLocalResolveHelper(specifier: string, fallbackToTsNodeRelative: boolean) {
+    return require.resolve(specifier, {
+      paths: fallbackToTsNodeRelative ? [localDirectory, __dirname] : [localDirectory]
+    });
+  }
+}
+/** @internal */
+export type ProjectLocalResolveHelper = ReturnType<typeof createProjectLocalResolveHelper>;
+
+/**
+ * Used as a reminder of all the factors we must consider when finding project-local dependencies and when a config file
+ * on disk may or may not exist.
+ * @internal
+ */
+export function getBasePathForProjectLocalDependencyResolution(configFilePath: string | undefined, projectSearchDirOption: string | undefined, projectOption: string | undefined, cwdOption: string) {
+  return configFilePath ?? projectSearchDirOption ?? projectOption ?? cwdOption;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -122,20 +122,32 @@ export function attemptRequireWithV8CompileCache(
  * @internal
  */
 export function createProjectLocalResolveHelper(localDirectory: string) {
-  return function projectLocalResolveHelper(specifier: string, fallbackToTsNodeRelative: boolean) {
+  return function projectLocalResolveHelper(
+    specifier: string,
+    fallbackToTsNodeRelative: boolean
+  ) {
     return require.resolve(specifier, {
-      paths: fallbackToTsNodeRelative ? [localDirectory, __dirname] : [localDirectory]
+      paths: fallbackToTsNodeRelative
+        ? [localDirectory, __dirname]
+        : [localDirectory],
     });
-  }
+  };
 }
 /** @internal */
-export type ProjectLocalResolveHelper = ReturnType<typeof createProjectLocalResolveHelper>;
+export type ProjectLocalResolveHelper = ReturnType<
+  typeof createProjectLocalResolveHelper
+>;
 
 /**
  * Used as a reminder of all the factors we must consider when finding project-local dependencies and when a config file
  * on disk may or may not exist.
  * @internal
  */
-export function getBasePathForProjectLocalDependencyResolution(configFilePath: string | undefined, projectSearchDirOption: string | undefined, projectOption: string | undefined, cwdOption: string) {
+export function getBasePathForProjectLocalDependencyResolution(
+  configFilePath: string | undefined,
+  projectSearchDirOption: string | undefined,
+  projectOption: string | undefined,
+  cwdOption: string
+) {
   return configFilePath ?? projectSearchDirOption ?? projectOption ?? cwdOption;
 }


### PR DESCRIPTION
Closes #1613

## Changes

- jsdoc for "swc" option links to website for instructions
- when @swc/core and @swc/wasm cannot be found, error message now links to ts-node website for assistance.
- implement generic mechanism for discovering dependencies relative to the project with fallback for global installations.  This mechanism supports other changes in this PR.
- swc transpiler attempts to resolve custom swc backend, @swc/core or @swc/wasm relative to project before attempting relative to (global) ts-node installation
  - previously only attempted relative to ts-node installation; global ts-node could only use global swc
- config loader sets `optionBasePaths` for `transpiler` and `compiler`, to prep for breaking change where we make them resolve relative to the tsconfig that declared them if it was an "extends" config