### PR TITLE
Make `TSError` `diagnosticText` non-enumerable to prevent it from logging below stack trace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -469,7 +469,7 @@ export class TSError extends BaseError {
     Object.defineProperty(this, 'diagnosticText', {
       configurable: true,
       writable: true,
-      value: diagnosticText
+      value: diagnosticText,
     });
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,9 +462,15 @@ export const DEFAULTS: RegisterOptions = {
  */
 export class TSError extends BaseError {
   name = 'TSError';
+  diagnosticText!: string;
 
-  constructor(public diagnosticText: string, public diagnosticCodes: number[]) {
+  constructor(diagnosticText: string, public diagnosticCodes: number[]) {
     super(`⨯ Unable to compile TypeScript:\n${diagnosticText}`);
+    Object.defineProperty(this, 'diagnosticText', {
+      configurable: true,
+      writable: true,
+      value: diagnosticText
+    });
   }
 
   /**


### PR DESCRIPTION
When ts-node throws a TSError, for example in the output below, you can see the `diagnosticText` logged below the stack trace.  This is ugly because it contains ANSI escapes, and it's verbose because it duplicates what you already saw above.  Fix is to make it non-enumerable.

```
d/Personal-dev/@TypeStrong/ts-node/issue-1435/tests/emit-skipped-fallback issue-1435*
❯ node ../../dist/bin ./src/index.ts
/d/Personal-dev/@TypeStrong/ts-node/issue-1435/src/index.ts:804
    return new TSError(diagnosticText, diagnosticCodes);
           ^
TSError: ⨯ Unable to compile TypeScript:
src/index.ts:3:7 - error TS2322: Type 'string' is not assignable to type 'number'.

3 const a: number = value;
        ~

    at createTSError (/d/Personal-dev/@TypeStrong/ts-node/issue-1435/src/index.ts:804:12)
    at reportTSError (/d/Personal-dev/@TypeStrong/ts-node/issue-1435/src/index.ts:808:19)
    at getOutput (/d/Personal-dev/@TypeStrong/ts-node/issue-1435/src/index.ts:998:36)
    at Object.compile (/d/Personal-dev/@TypeStrong/ts-node/issue-1435/src/index.ts:1300:30)
    at Module.m._compile (/d/Personal-dev/@TypeStrong/ts-node/issue-1435/src/index.ts:1429:30)
    at Module._extensions..js (node:internal/modules/cjs/loader:1149:10)
    at Object.require.extensions.<computed> [as .ts] (/d/Personal-dev/@TypeStrong/ts-node/issue-1435/src/index.ts:1433:12)
    at Module.load (node:internal/modules/cjs/loader:975:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12) {
  diagnosticText: "\x1B[96msrc/index.ts\x1B[0m:\x1B[93m3\x1B[0m:\x1B[93m7\x1B[0m - \x1B[91merror\x1B[0m\x1B[90m TS2322: \x1B[0mType 'string' is not assignable to type 'number'.\n" +
    '\n' +
    '\x1B[7m3\x1B[0m const a: number = value;\n' +
    '\x1B[7m \x1B[0m \x1B[91m      ~\x1B[0m\n',
  diagnosticCodes: [ 2322 ]
}
```