### PR TITLE
lazy-load dependencies to improve responsiveness when they aren't used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Module } from 'module';
 import * as util from 'util';
 import { fileURLToPath } from 'url';
 
-import sourceMapSupport = require('@cspotcode/source-map-support');
+import type * as _sourceMapSupport from '@cspotcode/source-map-support';
 import { BaseError } from 'make-error';
 import type * as _ts from 'typescript';
 
@@ -793,7 +793,7 @@ export function create(rawOptions: CreateOptions = {}): Service {
   // Install source map support and read from memory cache.
   installSourceMapSupport();
   function installSourceMapSupport() {
-    sourceMapSupport.install({
+    (require('@cspotcode/source-map-support') as typeof _sourceMapSupport).install({
       environment: 'node',
       retrieveFile(pathOrUrl: string) {
         let path = pathOrUrl;

--- a/src/index.ts
+++ b/src/index.ts
@@ -793,7 +793,9 @@ export function create(rawOptions: CreateOptions = {}): Service {
   // Install source map support and read from memory cache.
   installSourceMapSupport();
   function installSourceMapSupport() {
-    (require('@cspotcode/source-map-support') as typeof _sourceMapSupport).install({
+    const sourceMapSupport =
+      require('@cspotcode/source-map-support') as typeof _sourceMapSupport;
+    sourceMapSupport.install({
       environment: 'node',
       retrieveFile(pathOrUrl: string) {
         let path = pathOrUrl;

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -1,4 +1,4 @@
-import { diffLines } from 'diff';
+import type * as _diff from 'diff';
 import { homedir } from 'os';
 import { join } from 'path';
 import {
@@ -25,6 +25,13 @@ function getProcessTopLevelAwait() {
     } = require('../dist-raw/node-repl-await'));
   }
   return _processTopLevelAwait;
+}
+let diff: typeof _diff;
+function getDiffLines() {
+  if (diff === undefined) {
+    diff = require('diff');
+  }
+  return diff.diffLines;
 }
 
 /** @internal */
@@ -544,7 +551,7 @@ function appendCompileAndEvalInput(options: {
   );
 
   // Use `diff` to check for new JavaScript to execute.
-  const changes = diffLines(
+  const changes = getDiffLines()(
     oldOutputWithoutSourcemapComment,
     outputWithoutSourcemapComment
   );


### PR DESCRIPTION
diff is only used by the REPL.  @cspotcode/source-map-support is not used for e.g. `--showConfig`