### PR TITLE
Update warning suppressor to understand new phrasing of node's ESM Loader warning

### DIFF
--- a/src/child/child-require.ts
+++ b/src/child/child-require.ts
@@ -14,7 +14,7 @@ if (Array.isArray(_process._events.warning)) {
   _process._events.warning = onWarning;
 }
 
-const messageMatch = /--(?:experimental-)?loader\b/;
+const messageMatch = /(?:--(?:experimental-)?loader\b|\bCustom ESM Loaders\b)/;
 function onWarning(this: any, warning: Error, ...rest: any[]) {
   // Suppress warning about how `--loader` is experimental
   if (


### PR DESCRIPTION
Node nightly changed the phrasing of this warning.  So we update our suppressor to match this new phrasing and correctly suppress the warning.