### PR TITLE
Cleanup test macros

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,30 @@ We have a debug configuration for VSCode.
 Note that some tests might misbehave in the debugger.  REPL tests in particular.  I'm not sure why, but I think it is related to how `console` does not write to
 stdout when in a debug session.
 
+### Test Context
+
+Ava has the concept of test "context", an object which can store reusable fields common across many tests.
+
+By convention, any functions that setup reusable context start with `ctx`, making them easier to tab-complete and auto-import while writing tests.
+
+See `ctxTsNode` for an example.
+
+Context setup functions are re-executed for each test case.  If you don't want this, wrap the context function in lodash `once()`.  Each test will still get a unique context object, but the values placed onto each context will be identical.
+
+Every `ctx*` function has a namespace with `Ctx` and `T` types.  These make it easier/cleaner to write tests.
+
+### Test Macros
+
+Ava has the concept of test "macros", reusable functions which can declare a type of test many times with different inputs.
+
+Macro functions are created with `test.macro()`.
+
+By convention, if a macro function is meant to be imported and reused in multiple files, its name should start with `macro`.
+
+Macros can also be declared to require a certain "context," thanks to the namespace types described in "Test Context" above.
+
+See examples in `helpers.ts`.
+
 ## Documentation
 
 Documentation is written in markdown in `website/docs` and rendered into a website by Docusaurus.  The README is also generated from these markdown files.

--- a/src/test/diagnostics.spec.ts
+++ b/src/test/diagnostics.spec.ts
@@ -1,9 +1,9 @@
 import type { TSError } from '..';
-import { contextTsNodeUnderTest, ts } from './helpers';
+import { ctxTsNode, ts } from './helpers';
 import { context, expect } from './testlib';
 import * as semver from 'semver';
 import { once } from 'lodash';
-const test = context(contextTsNodeUnderTest);
+const test = context(ctxTsNode);
 
 test.suite('TSError diagnostics', ({ context }) => {
   const test = context(

--- a/src/test/esm-loader.spec.ts
+++ b/src/test/esm-loader.spec.ts
@@ -10,7 +10,7 @@ import {
   BIN_PATH_JS,
   CMD_ESM_LOADER_WITHOUT_PROJECT,
   CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
-  contextTsNodeUnderTest,
+  ctxTsNode,
   delay,
   EXPERIMENTAL_MODULES_FLAG,
   nodeSupportsEsmHooks,
@@ -26,7 +26,7 @@ import * as expect from 'expect';
 import type { NodeLoaderHooksAPI2 } from '../';
 import { pathToFileURL } from 'url';
 
-const test = context(contextTsNodeUnderTest);
+const test = context(ctxTsNode);
 
 const exec = createExec({
   cwd: TEST_DIR,
@@ -233,8 +233,8 @@ test.suite('esm', (test) => {
       });
     });
 
-    test.suite('unit test hooks', (_test) => {
-      const test = _test.context(async (t) => {
+    test.suite('unit test hooks', ({ context }) => {
+      const test = context(async (t) => {
         const service = t.context.tsNodeUnderTest.create({
           cwd: TEST_DIR,
         });

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -14,6 +14,7 @@ import type * as tsNodeTypes from '../index';
 import type _createRequire from 'create-require';
 import { has, mapValues, once } from 'lodash';
 import semver = require('semver');
+import type { ExecutionContext } from './testlib';
 const createRequire: typeof _createRequire = require('create-require');
 export { tsNodeTypes };
 
@@ -79,13 +80,17 @@ export const tsSupportsShowConfig = semver.gte(ts.version, '3.2.0');
 export const xfs = new NodeFS(fs);
 
 /** Pass to `test.context()` to get access to the ts-node API under test */
-export const contextTsNodeUnderTest = once(async () => {
+export const ctxTsNode = once(async () => {
   await installTsNode();
   const tsNodeUnderTest: typeof tsNodeTypes = testsDirRequire('ts-node');
   return {
     tsNodeUnderTest,
   };
 });
+export namespace ctxTsNode {
+  export type Ctx = Awaited<ReturnType<typeof ctxTsNode>>;
+  export type T = ExecutionContext<Ctx>;
+}
 
 //#region install ts-node tarball
 const ts_node_install_lock = process.env.ts_node_install_lock as string;

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -1,4 +1,4 @@
-import { _test } from './testlib';
+import { context } from './testlib';
 import * as expect from 'expect';
 import { join, resolve, sep as pathSep } from 'path';
 import { tmpdir } from 'os';
@@ -14,7 +14,6 @@ import {
 import { lstatSync, mkdtempSync } from 'fs';
 import { npath } from '@yarnpkg/fslib';
 import type _createRequire from 'create-require';
-import { pathToFileURL } from 'url';
 import { createExec } from './exec-helpers';
 import {
   BIN_CWD_PATH,
@@ -26,18 +25,17 @@ import {
   testsDirRequire,
   tsNodeTypes,
   xfs,
-  contextTsNodeUnderTest,
+  ctxTsNode,
   CMD_TS_NODE_WITH_PROJECT_FLAG,
   CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
   CMD_ESM_LOADER_WITHOUT_PROJECT,
-  EXPERIMENTAL_MODULES_FLAG,
 } from './helpers';
 
 const exec = createExec({
   cwd: TEST_DIR,
 });
 
-const test = _test.context(contextTsNodeUnderTest);
+const test = context(ctxTsNode);
 
 test.suite('ts-node', (test) => {
   test('should export the correct version', (t) => {
@@ -709,8 +707,8 @@ test.suite('ts-node', (test) => {
 
     test.suite(
       'should use implicit @tsconfig/bases config when one is not loaded from disk',
-      (_test) => {
-        const test = _test.context(async (t) => ({
+      ({ context }) => {
+        const test = context(async (t) => ({
           tempDir: mkdtempSync(join(tmpdir(), 'ts-node-spec')),
         }));
         if (
@@ -941,8 +939,8 @@ test.suite('ts-node', (test) => {
     });
   });
 
-  test.suite('create', (_test) => {
-    const test = _test.context(async (t) => {
+  test.suite('create', ({ context }) => {
+    const test = context(async (t) => {
       return {
         service: t.context.tsNodeUnderTest.create({
           compilerOptions: { target: 'es5' },

--- a/src/test/pluggable-dep-resolution.spec.ts
+++ b/src/test/pluggable-dep-resolution.spec.ts
@@ -1,6 +1,6 @@
 import { context } from './testlib';
 import {
-  contextTsNodeUnderTest,
+  ctxTsNode,
   resetNodeEnvironment,
   TEST_DIR,
   tsSupportsTsconfigInheritanceViaNodePackages,
@@ -8,7 +8,7 @@ import {
 import * as expect from 'expect';
 import { resolve } from 'path';
 
-const test = context(contextTsNodeUnderTest);
+const test = context(ctxTsNode);
 
 test.suite(
   'Pluggable dependency (compiler, transpiler, swc backend) is require()d relative to the tsconfig file that declares it',
@@ -26,64 +26,9 @@ test.suite(
     // ts-node should resolve ts-patch or @swc/core relative to the extended tsconfig
     // to ensure we use the known working versions.
 
-    const macro = _macro.bind(null, test);
-
-    macro('tsconfig-custom-compiler.json', 'root custom compiler');
-    macro('tsconfig-custom-transpiler.json', 'root custom transpiler');
-    macro('tsconfig-swc-custom-backend.json', 'root custom swc backend');
-    macro('tsconfig-swc-core.json', 'root @swc/core');
-    macro('tsconfig-swc-wasm.json', 'root @swc/wasm');
-    macro('tsconfig-swc.json', 'root @swc/core');
-
-    macro(
-      'node_modules/shared-config/tsconfig-custom-compiler.json',
-      'shared-config custom compiler'
-    );
-    macro(
-      'node_modules/shared-config/tsconfig-custom-transpiler.json',
-      'shared-config custom transpiler'
-    );
-    macro(
-      'node_modules/shared-config/tsconfig-swc-custom-backend.json',
-      'shared-config custom swc backend'
-    );
-    macro(
-      'node_modules/shared-config/tsconfig-swc-core.json',
-      'shared-config @swc/core'
-    );
-    macro(
-      'node_modules/shared-config/tsconfig-swc-wasm.json',
-      'shared-config @swc/wasm'
-    );
-    macro(
-      'node_modules/shared-config/tsconfig-swc.json',
-      'shared-config @swc/core'
-    );
-
-    test.suite('"extends"', (test) => {
-      test.runIf(tsSupportsTsconfigInheritanceViaNodePackages);
-
-      const macro = _macro.bind(null, test);
-
-      macro(
-        'tsconfig-extend-custom-compiler.json',
-        'shared-config custom compiler'
-      );
-      macro(
-        'tsconfig-extend-custom-transpiler.json',
-        'shared-config custom transpiler'
-      );
-      macro(
-        'tsconfig-extend-swc-custom-backend.json',
-        'shared-config custom swc backend'
-      );
-      macro('tsconfig-extend-swc-core.json', 'shared-config @swc/core');
-      macro('tsconfig-extend-swc-wasm.json', 'shared-config @swc/wasm');
-      macro('tsconfig-extend-swc.json', 'shared-config @swc/core');
-    });
-
-    function _macro(_test: typeof test, config: string, expected: string) {
-      _test(`${config} uses ${expected}`, async (t) => {
+    const macro = test.macro((config: string, expected: string) => [
+      `${config} uses ${expected}`,
+      async (t) => {
         t.teardown(resetNodeEnvironment);
 
         const output = t.context.tsNodeUnderTest
@@ -93,7 +38,68 @@ test.suite(
           .compile('', 'index.ts');
 
         expect(output).toContain(`emit from ${expected}\n`);
-      });
-    }
+      },
+    ]);
+
+    test(macro, 'tsconfig-custom-compiler.json', 'root custom compiler');
+    test(macro, 'tsconfig-custom-transpiler.json', 'root custom transpiler');
+    test(macro, 'tsconfig-swc-custom-backend.json', 'root custom swc backend');
+    test(macro, 'tsconfig-swc-core.json', 'root @swc/core');
+    test(macro, 'tsconfig-swc-wasm.json', 'root @swc/wasm');
+    test(macro, 'tsconfig-swc.json', 'root @swc/core');
+
+    test(
+      macro,
+      'node_modules/shared-config/tsconfig-custom-compiler.json',
+      'shared-config custom compiler'
+    );
+    test(
+      macro,
+      'node_modules/shared-config/tsconfig-custom-transpiler.json',
+      'shared-config custom transpiler'
+    );
+    test(
+      macro,
+      'node_modules/shared-config/tsconfig-swc-custom-backend.json',
+      'shared-config custom swc backend'
+    );
+    test(
+      macro,
+      'node_modules/shared-config/tsconfig-swc-core.json',
+      'shared-config @swc/core'
+    );
+    test(
+      macro,
+      'node_modules/shared-config/tsconfig-swc-wasm.json',
+      'shared-config @swc/wasm'
+    );
+    test(
+      macro,
+      'node_modules/shared-config/tsconfig-swc.json',
+      'shared-config @swc/core'
+    );
+
+    test.suite('"extends"', (test) => {
+      test.runIf(tsSupportsTsconfigInheritanceViaNodePackages);
+
+      test(
+        macro,
+        'tsconfig-extend-custom-compiler.json',
+        'shared-config custom compiler'
+      );
+      test(
+        macro,
+        'tsconfig-extend-custom-transpiler.json',
+        'shared-config custom transpiler'
+      );
+      test(
+        macro,
+        'tsconfig-extend-swc-custom-backend.json',
+        'shared-config custom swc backend'
+      );
+      test(macro, 'tsconfig-extend-swc-core.json', 'shared-config @swc/core');
+      test(macro, 'tsconfig-extend-swc-wasm.json', 'shared-config @swc/wasm');
+      test(macro, 'tsconfig-extend-swc.json', 'shared-config @swc/core');
+    });
   }
 );

--- a/src/test/register.spec.ts
+++ b/src/test/register.spec.ts
@@ -1,6 +1,6 @@
 import { once } from 'lodash';
 import {
-  contextTsNodeUnderTest,
+  ctxTsNode,
   PROJECT_TRANSPILE_ONLY,
   resetNodeEnvironment,
   TEST_DIR,
@@ -22,7 +22,7 @@ const createOptions: tsNodeTypes.CreateOptions = {
   },
 };
 
-const test = context(contextTsNodeUnderTest).context(
+const test = context(ctxTsNode).context(
   once(async (t) => {
     return {
       moduleTestPath: resolve(__dirname, '../../tests/module.ts'),

--- a/src/test/regression.spec.ts
+++ b/src/test/regression.spec.ts
@@ -5,12 +5,12 @@ import { join } from 'path';
 import { createExec, createExecTester } from './exec-helpers';
 import {
   CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
-  contextTsNodeUnderTest,
+  ctxTsNode,
   TEST_DIR,
 } from './helpers';
-import { test as _test } from './testlib';
+import { context } from './testlib';
 
-const test = _test.context(contextTsNodeUnderTest);
+const test = context(ctxTsNode);
 const exec = createExecTester({
   exec: createExec({
     cwd: TEST_DIR,

--- a/src/test/repl/helpers.ts
+++ b/src/test/repl/helpers.ts
@@ -1,19 +1,7 @@
-import * as promisify from 'util.promisify';
 import { PassThrough } from 'stream';
-import { getStream, TEST_DIR, tsNodeTypes } from '../helpers';
+import { delay, getStream, TEST_DIR, tsNodeTypes, ctxTsNode } from '../helpers';
 import type { ExecutionContext } from 'ava';
-import { test, expect, TestInterface } from '../testlib';
-
-export interface ContextWithTsNodeUnderTest {
-  tsNodeUnderTest: Pick<
-    typeof tsNodeTypes,
-    'create' | 'register' | 'createRepl'
-  >;
-}
-
-export type ContextWithReplHelpers = ContextWithTsNodeUnderTest &
-  Awaited<ReturnType<typeof contextReplHelpers>>;
-export type ReplExecutionContext = ExecutionContext<ContextWithReplHelpers>;
+import { test, expect } from '../testlib';
 
 export interface CreateReplViaApiOptions {
   registerHooks: boolean;
@@ -30,12 +18,15 @@ export interface ExecuteInReplOptions extends CreateReplViaApiOptions {
   >[0];
 }
 
+export namespace ctxRepl {
+  export type Ctx = ctxTsNode.Ctx & Awaited<ReturnType<typeof ctxRepl>>;
+  export type T = ExecutionContext<Ctx>;
+}
+
 /**
  * pass to test.context() to get REPL testing helper functions
  */
-export async function contextReplHelpers(
-  t: ExecutionContext<ContextWithTsNodeUnderTest>
-) {
+export async function ctxRepl(t: ctxTsNode.T) {
   const { tsNodeUnderTest } = t.context;
   return { createReplViaApi, executeInRepl };
 
@@ -90,11 +81,7 @@ export async function contextReplHelpers(
     const stdoutPromise = getStream(stdout, waitPattern);
     const stderrPromise = getStream(stderr, waitPattern);
     // Wait for expected output pattern or timeout, whichever comes first
-    await Promise.race([
-      promisify(setTimeout)(waitMs),
-      stdoutPromise,
-      stderrPromise,
-    ]);
+    await Promise.race([delay(waitMs), stdoutPromise, stderrPromise]);
     stdout.end();
     stderr.end();
 
@@ -106,70 +93,20 @@ export async function contextReplHelpers(
   }
 }
 
-export function replMacros<T extends ContextWithReplHelpers>(
-  _test: TestInterface<T>
-) {
-  return { noErrorsAndStdoutContains, stderrContains };
-
-  function noErrorsAndStdoutContains(
-    title: string,
-    script: string,
-    contains: string,
-    options?: Partial<ExecuteInReplOptions>
-  ) {
-    testReplInternal(title, script, contains, undefined, contains, options);
-  }
-  function stderrContains(
-    title: string,
-    script: string,
-    errorContains: string,
-    options?: Partial<ExecuteInReplOptions>
-  ) {
-    testReplInternal(
-      title,
-      script,
-      undefined,
-      errorContains,
-      errorContains,
-      options
-    );
-  }
-  function testReplInternal(
-    title: string,
-    script: string,
-    stdoutContains: string | undefined,
-    stderrContains: string | undefined,
-    waitPattern: string,
-    options?: Partial<ExecuteInReplOptions>
-  ) {
-    _test(title, async (t) => {
-      const { stdout, stderr } = await t.context.executeInRepl(script, {
-        registerHooks: true,
-        startInternalOptions: { useGlobal: false },
-        waitPattern,
-        ...options,
-      });
-      if (stderrContains) expect(stderr).toContain(stderrContains);
-      else expect(stderr).toBe('');
-      if (stdoutContains) expect(stdout).toContain(stdoutContains);
-    });
-  }
-}
-
-const noErrorsAndStdoutContains = test.macro(
+export const macroReplNoErrorsAndStdoutContains = test.macro(
   (script: string, contains: string, options?: Partial<ExecuteInReplOptions>) =>
-    async (t: ExecutionContext<ContextWithReplHelpers>) => {
-      testReplInternal(t, script, contains, undefined, contains, options);
+    async (t: ctxRepl.T) => {
+      macroReplInternal(t, script, contains, undefined, contains, options);
     }
 );
-const stderrContains = test.macro(
+export const macroReplStderrContains = test.macro(
   (
       script: string,
       errorContains: string,
       options?: Partial<ExecuteInReplOptions>
     ) =>
-    async (t: ReplExecutionContext) => {
-      testReplInternal(
+    async (t: ctxRepl.T) => {
+      macroReplInternal(
         t,
         script,
         undefined,
@@ -180,8 +117,8 @@ const stderrContains = test.macro(
     }
 );
 
-async function testReplInternal(
-  t: ExecutionContext<ContextWithReplHelpers>,
+async function macroReplInternal(
+  t: ctxRepl.T,
   script: string,
   stdoutContains: string | undefined,
   stderrContains: string | undefined,
@@ -198,4 +135,3 @@ async function testReplInternal(
   else expect(stderr).toBe('');
   if (stdoutContains) expect(stdout).toContain(stdoutContains);
 }
-export const replMacros_ = { noErrorsAndStdoutContains, stderrContains };

--- a/src/test/repl/node-repl-tla.ts
+++ b/src/test/repl/node-repl-tla.ts
@@ -3,10 +3,10 @@ import type { Key } from 'readline';
 import { Stream } from 'stream';
 import semver = require('semver');
 import { ts } from '../helpers';
-import type { ContextWithTsNodeUnderTest } from './helpers';
+import type { ctxTsNode } from '../helpers';
 import { nodeSupportsEsmHooks } from '../helpers';
 
-interface SharedObjects extends ContextWithTsNodeUnderTest {
+interface SharedObjects extends ctxTsNode.Ctx {
   TEST_DIR: string;
 }
 

--- a/src/test/repl/repl-environment.spec.ts
+++ b/src/test/repl/repl-environment.spec.ts
@@ -3,21 +3,20 @@
  * globals, __filename, builtin module accessors.
  */
 
-import { test as _test, expect } from '../testlib';
-import * as promisify from 'util.promisify';
+import { context, expect } from '../testlib';
 import * as getStream from 'get-stream';
 import {
   CMD_TS_NODE_WITH_PROJECT_FLAG,
-  contextTsNodeUnderTest,
-  ROOT_DIR,
+  ctxTsNode,
+  delay,
   TEST_DIR,
 } from '../helpers';
 import { dirname, join } from 'path';
 import { createExec, createExecTester } from '../exec-helpers';
 import { homedir } from 'os';
-import { contextReplHelpers } from './helpers';
+import { ctxRepl } from './helpers';
 
-const test = _test.context(contextTsNodeUnderTest).context(contextReplHelpers);
+const test = context(ctxTsNode).context(ctxRepl);
 
 const exec = createExec({
   cwd: TEST_DIR,
@@ -75,10 +74,10 @@ test.suite(
           stdin.end();
           let done = false;
           await Promise.race([
-            promisify(setTimeout)(20e3),
+            delay(20e3),
             (async () => {
               while (!done && !waitFor?.()) {
-                await promisify(setTimeout)(1e3);
+                await delay(1e3);
               }
             })(),
           ]);

--- a/src/test/sourcemaps.spec.ts
+++ b/src/test/sourcemaps.spec.ts
@@ -1,12 +1,8 @@
 import * as expect from 'expect';
 import { createExec, createExecTester } from './exec-helpers';
-import {
-  CMD_TS_NODE_WITH_PROJECT_FLAG,
-  contextTsNodeUnderTest,
-  TEST_DIR,
-} from './helpers';
-import { test as _test } from './testlib';
-const test = _test.context(contextTsNodeUnderTest);
+import { CMD_TS_NODE_WITH_PROJECT_FLAG, ctxTsNode, TEST_DIR } from './helpers';
+import { context } from './testlib';
+const test = context(ctxTsNode);
 
 const exec = createExecTester({
   cmd: CMD_TS_NODE_WITH_PROJECT_FLAG,

--- a/src/test/testlib.ts
+++ b/src/test/testlib.ts
@@ -89,17 +89,17 @@ export interface TestInterface<
     ...rest: T
   ): void;
 
-  macro<Args extends any[]>(
+  macro<Args extends any[], Ctx = Context>(
     cb: (
       ...args: Args
     ) =>
       | [
           (title: string | undefined) => string | undefined,
-          (t: ExecutionContext<Context>) => Promise<void>
+          (t: ExecutionContext<Ctx>) => Promise<void>
         ]
-      | ((t: ExecutionContext<Context>) => Promise<void>)
+      | ((t: ExecutionContext<Ctx>) => Promise<void>)
   ): (
-    test: ExecutionContext<Context>,
+    test: ExecutionContext<Ctx>,
     ...args: Args
   ) => Promise<void> & {
     title(givenTitle: string | undefined, ...args: Args): string;

--- a/src/test/transpilers.spec.ts
+++ b/src/test/transpilers.spec.ts
@@ -3,10 +3,10 @@
 // Should consolidate them here.
 
 import { context } from './testlib';
-import { contextTsNodeUnderTest, testsDirRequire } from './helpers';
+import { ctxTsNode, testsDirRequire } from './helpers';
 import * as expect from 'expect';
 
-const test = context(contextTsNodeUnderTest);
+const test = context(ctxTsNode);
 
 test.suite('swc', (test) => {
   test('verify that TS->SWC target mappings suppport all possible values from both TS and SWC', async (t) => {


### PR DESCRIPTION
Making the tests more consistent.  In particular, converging on the use of ava macros, making them look nicer, improving functionality for macros computing their own titles.