### PR TITLE
fix(docs): Clarify `--project` shorthand option description

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ All command-line flags support both `--camelCase` and `--hyphen-case`.
 
 ## TSConfig
 
-*   `-P, --project [path]`   Path to TypeScript JSON project file <br/>*Environment:* `TS_NODE_PROJECT`
+*   `-P, --project [path]`   Path to TypeScript JSON project file. (Note the uppercase - this is different from `tsc`'s `-p/--project` option.) <br/>*Environment:* `TS_NODE_PROJECT`
 *   `--skipProject`   Skip project config resolution and loading <br/>*Default:* `false` <br/>*Environment:* `TS_NODE_SKIP_PROJECT`
 *   `-c, --cwdMode`   Resolve config relative to the current directory instead of the directory of the entrypoint script
 *   `-O, --compilerOptions [opts]`   JSON object to merge with compiler options <br/>*Environment:* `TS_NODE_COMPILER_OPTIONS`


### PR DESCRIPTION
To hopefully save anyone else the 45 minutes I wasted because I am not a good noticer.

Because of `tsc`'s `-p` shorthand for the `--project` option, when I saw that `ts-node` had a similar option, I didn't read closely enough to see that in `ts-node`'s case, it's a capital P.