### PR TITLE
`getTypeInfo` should normalize slashes in path before querying our internal APIs for type info

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1097,9 +1097,10 @@ export function createFromPreloadedConfig(
       };
 
       getTypeInfo = (code: string, fileName: string, position: number) => {
-        updateMemoryCache(code, fileName);
+        const normalizedFileName = normalizeSlashes(fileName);
+        updateMemoryCache(code, normalizedFileName);
 
-        const info = service.getQuickInfoAtPosition(fileName, position);
+        const info = service.getQuickInfoAtPosition(normalizedFileName, position);
         const name = ts.displayPartsToString(info ? info.displayParts : []);
         const comment = ts.displayPartsToString(info ? info.documentation : []);
 
@@ -1283,9 +1284,10 @@ export function createFromPreloadedConfig(
       };
 
       getTypeInfo = (code: string, fileName: string, position: number) => {
-        updateMemoryCache(code, fileName);
+        const normalizedFileName = normalizeSlashes(fileName);
+        updateMemoryCache(code, normalizedFileName);
 
-        const sourceFile = builderProgram.getSourceFile(fileName);
+        const sourceFile = builderProgram.getSourceFile(normalizedFileName);
         if (!sourceFile)
           throw new TypeError(`Unable to read file: ${fileName}`);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1100,7 +1100,10 @@ export function createFromPreloadedConfig(
         const normalizedFileName = normalizeSlashes(fileName);
         updateMemoryCache(code, normalizedFileName);
 
-        const info = service.getQuickInfoAtPosition(normalizedFileName, position);
+        const info = service.getQuickInfoAtPosition(
+          normalizedFileName,
+          position
+        );
         const name = ts.displayPartsToString(info ? info.displayParts : []);
         const comment = ts.displayPartsToString(info ? info.documentation : []);
 


### PR DESCRIPTION
Fixes #1761 