### PR TITLE
Use basename in source map sources field

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1668,7 +1668,7 @@ function updateOutput(
 function updateSourceMap(sourceMapText: string, fileName: string) {
   const sourceMap = JSON.parse(sourceMapText);
   sourceMap.file = fileName;
-  sourceMap.sources = [fileName];
+  sourceMap.sources = [basename(fileName)];
   delete sourceMap.sourceRoot;
   return JSON.stringify(sourceMap);
 }


### PR DESCRIPTION
Resolves #1769 by using the base name of the file instead of the full path in the source map `sources` field.