### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         os: [ubuntu, windows]
         # Don't forget to add all new flavors to this list!
-        flavor: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+        flavor: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
         include:
           # Node 12.15
           - flavor: 1
@@ -95,64 +95,47 @@ jobs:
             nodeFlag: 14
             typescript: next
             typescriptFlag: next
-          - flavor: 8
-            node: 14
-            nodeFlag: 14
-            typescript: rc
-            typescriptFlag: rc
           # Node 16
           # Node 16.11.1
           # Earliest version that supports old ESM Loader Hooks API: https://github.com/TypeStrong/ts-node/pull/1522
-          - flavor: 9
+          - flavor: 8
             node: 16.11.1
             nodeFlag: 16_11_1
             typescript: latest
             typescriptFlag: latest
-          - flavor: 10
+          - flavor: 9
             node: 16
             nodeFlag: 16
             typescript: latest
             typescriptFlag: latest
             downgradeNpm: true
-          - flavor: 11
+          - flavor: 10
             node: 16
             nodeFlag: 16
             typescript: 2.7
             typescriptFlag: 2_7
             downgradeNpm: true
-          - flavor: 12
+          - flavor: 11
             node: 16
             nodeFlag: 16
             typescript: next
             typescriptFlag: next
             downgradeNpm: true
-          - flavor: 13
-            node: 16
-            nodeFlag: 16
-            typescript: rc
-            typescriptFlag: rc
-            downgradeNpm: true
           # Node 18
-          - flavor: 14
+          - flavor: 12
             node: 18
             nodeFlag: 18
             typescript: latest
             typescriptFlag: latest
             downgradeNpm: true
-          - flavor: 15
+          - flavor: 13
             node: 18
             nodeFlag: 18
             typescript: next
             typescriptFlag: next
             downgradeNpm: true
-          - flavor: 16
-            node: 18
-            nodeFlag: 18
-            typescript: rc
-            typescriptFlag: rc
-            downgradeNpm: true
           # Node nightly
-          - flavor: 17
+          - flavor: 14
             node: nightly
             nodeFlag: nightly
             typescript: latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -4670,9 +4670,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
-      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
       "dev": true
     },
     "typescript-json-schema": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "semver": "^7.1.3",
     "throat": "^6.0.1",
     "typedoc": "^0.22.10",
-    "typescript": "4.6.4",
+    "typescript": "4.7.2",
     "typescript-json-schema": "^0.53.0",
     "util.promisify": "^1.0.1"
   },

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -68,6 +68,14 @@ export const nodeSupportsImportAssertions = semver.gte(
   process.version,
   '17.1.0'
 );
+// Node 14.13.0 has a bug where it tries to lex CJS files to discover named exports *before*
+// we transform the code.
+// In other words, it tries to parse raw TS as CJS and balks at `export const foo =`, expecting to see `exports.foo =`
+// This lexing only happens when CJS TS is imported from the ESM loader.
+export const nodeSupportsImportingTransformedCjsFromEsm = semver.gte(
+  process.version,
+  '14.13.1'
+);
 /** Supports tsconfig "extends" >= v3.2.0 */
 export const tsSupportsTsconfigInheritanceViaNodePackages = semver.gte(
   ts.version,

--- a/src/test/module-node.spec.ts
+++ b/src/test/module-node.spec.ts
@@ -2,6 +2,7 @@ import { expect, context } from './testlib';
 import {
   CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
   isOneOf,
+  nodeSupportsImportingTransformedCjsFromEsm,
   resetNodeEnvironment,
   tsSupportsStableNodeNextNode16,
 } from './helpers';
@@ -18,7 +19,9 @@ type Test = typeof test;
 
 // Declare one test case for each permutations of project configuration
 test.suite('TypeScript module=NodeNext and Node16', (test) => {
-  test.runIf(tsSupportsStableNodeNextNode16);
+  test.runIf(
+    tsSupportsStableNodeNextNode16 && nodeSupportsImportingTransformedCjsFromEsm
+  );
 
   for (const allowJs of [true, false]) {
     for (const typecheckMode of [
@@ -63,6 +66,7 @@ function declareTest(test: Test, testParams: TestParams) {
     t.log(stdout);
     t.log(stderr);
     expect(err).toBe(null);
+    expect(stdout).toMatch(/done\n$/);
   });
 }
 
@@ -215,6 +219,8 @@ function writeFixturesToFilesystem(name: string, testParams: TestParams) {
       indexFile.content += `await import('${importSpecifier}');\n`;
     }
   }
+
+  indexFile.content += `console.log('done');\n`;
 
   proj.rm();
   proj.write();


### PR DESCRIPTION
After TS 4.7 was released stable, the test matrix started running TS 4.7 combined with node 14.13.0 and node12.  Previously, the test matrix had only been combining TS 4.7 RC with node 14.x (newest v14), 16.x, and 18x.

This caused us to, yet again, hit a node 14.13.0 bug.

Note that this is not the same as #1774, an unrelated node bug that coincidentally started happening on the same night.