### PR TITLE
Fix #1778: typechecker resolver should take importer's module type -- cjs or esm -- into account when resolving package.json "exports"

### DIFF
--- a/src/resolver-functions.ts
+++ b/src/resolver-functions.ts
@@ -99,7 +99,12 @@ export function createResolverFunctions(kwargs: {
       containingSourceFile?: TSCommon.SourceFile
     ): (TSCommon.ResolvedModule | undefined)[] => {
       return moduleNames.map((moduleName, i) => {
-        const mode = containingSourceFile ? (ts as any as TSInternal).getModeForResolutionAtIndex?.(containingSourceFile, i) : undefined;
+        const mode = containingSourceFile
+          ? (ts as any as TSInternal).getModeForResolutionAtIndex?.(
+              containingSourceFile,
+              i
+            )
+          : undefined;
         const { resolvedModule } = ts.resolveModuleName(
           moduleName,
           containingFile,
@@ -107,7 +112,7 @@ export function createResolverFunctions(kwargs: {
           host,
           moduleResolutionCache,
           redirectedReference,
-          mode,
+          mode
         );
         if (resolvedModule) {
           fixupResolvedModule(resolvedModule);

--- a/src/resolver-functions.ts
+++ b/src/resolver-functions.ts
@@ -98,7 +98,8 @@ export function createResolverFunctions(kwargs: {
       optionsOnlyWithNewerTsVersions: TSCommon.CompilerOptions,
       containingSourceFile?: TSCommon.SourceFile
     ): (TSCommon.ResolvedModule | undefined)[] => {
-      return moduleNames.map((moduleName) => {
+      return moduleNames.map((moduleName, i) => {
+        const mode = containingSourceFile ? (ts as any as TSInternal).getModeForResolutionAtIndex?.(containingSourceFile, i) : undefined;
         const { resolvedModule } = ts.resolveModuleName(
           moduleName,
           containingFile,
@@ -106,9 +107,7 @@ export function createResolverFunctions(kwargs: {
           host,
           moduleResolutionCache,
           redirectedReference,
-          containingSourceFile?.impliedNodeFormat
-
-          // (ts as any as typeof import('typescript')).getModeForResolutionAtIndex(containingSourceFile)
+          mode,
         );
         if (resolvedModule) {
           fixupResolvedModule(resolvedModule);

--- a/src/resolver-functions.ts
+++ b/src/resolver-functions.ts
@@ -95,7 +95,8 @@ export function createResolverFunctions(kwargs: {
       containingFile: string,
       reusedNames: string[] | undefined,
       redirectedReference: TSCommon.ResolvedProjectReference | undefined,
-      optionsOnlyWithNewerTsVersions: TSCommon.CompilerOptions
+      optionsOnlyWithNewerTsVersions: TSCommon.CompilerOptions,
+      containingSourceFile?: TSCommon.SourceFile
     ): (TSCommon.ResolvedModule | undefined)[] => {
       return moduleNames.map((moduleName) => {
         const { resolvedModule } = ts.resolveModuleName(
@@ -104,7 +105,10 @@ export function createResolverFunctions(kwargs: {
           config.options,
           host,
           moduleResolutionCache,
-          redirectedReference
+          redirectedReference,
+          containingSourceFile?.impliedNodeFormat
+
+          // (ts as any as typeof import('typescript')).getModeForResolutionAtIndex(containingSourceFile)
         );
         if (resolvedModule) {
           fixupResolvedModule(resolvedModule);
@@ -117,12 +121,14 @@ export function createResolverFunctions(kwargs: {
   const getResolvedModuleWithFailedLookupLocationsFromCache: TSCommon.LanguageServiceHost['getResolvedModuleWithFailedLookupLocationsFromCache'] =
     (
       moduleName,
-      containingFile
+      containingFile,
+      resolutionMode?: TSCommon.ModuleKind.CommonJS | TSCommon.ModuleKind.ESNext
     ): TSCommon.ResolvedModuleWithFailedLookupLocations | undefined => {
       const ret = ts.resolveModuleNameFromCache(
         moduleName,
         containingFile,
-        moduleResolutionCache
+        moduleResolutionCache,
+        resolutionMode
       );
       if (ret && ret.resolvedModule) {
         fixupResolvedModule(ret.resolvedModule);

--- a/src/test/module-node/1778.spec.ts
+++ b/src/test/module-node/1778.spec.ts
@@ -1,0 +1,33 @@
+import { createExec } from '../exec-helpers';
+import {
+  ctxTsNode,
+  nodeSupportsEsmHooks,
+  TEST_DIR,
+  tsSupportsStableNodeNextNode16,
+  CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
+} from '../helpers';
+import { context, expect } from '../testlib';
+import { join } from 'path';
+
+const exec = createExec({
+  cwd: TEST_DIR,
+});
+
+const test = context(ctxTsNode);
+
+test.suite(
+  'Issue #1778: typechecker resolver should take importer\'s module type -- cjs or esm -- into account when resolving package.json "exports"',
+  (test) => {
+    test.runIf(nodeSupportsEsmHooks && tsSupportsStableNodeNextNode16);
+    test('test', async () => {
+      const { err, stdout } = await exec(
+        `${CMD_TS_NODE_WITHOUT_PROJECT_FLAG} ./index.ts`,
+        {
+          cwd: join(TEST_DIR, '1778'),
+        }
+      );
+      expect(err).toBe(null);
+      expect(stdout).toBe('0\n');
+    });
+  }
+);

--- a/src/test/module-node/1778.spec.ts
+++ b/src/test/module-node/1778.spec.ts
@@ -5,6 +5,7 @@ import {
   TEST_DIR,
   tsSupportsStableNodeNextNode16,
   CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
+  nodeSupportsSpawningChildProcess,
 } from '../helpers';
 import { context, expect } from '../testlib';
 import { join } from 'path';
@@ -18,7 +19,7 @@ const test = context(ctxTsNode);
 test.suite(
   'Issue #1778: typechecker resolver should take importer\'s module type -- cjs or esm -- into account when resolving package.json "exports"',
   (test) => {
-    test.runIf(nodeSupportsEsmHooks && tsSupportsStableNodeNextNode16);
+    test.runIf(nodeSupportsEsmHooks && nodeSupportsSpawningChildProcess && tsSupportsStableNodeNextNode16);
     test('test', async () => {
       const { err, stdout } = await exec(
         `${CMD_TS_NODE_WITHOUT_PROJECT_FLAG} ./index.ts`,

--- a/src/test/module-node/1778.spec.ts
+++ b/src/test/module-node/1778.spec.ts
@@ -27,7 +27,7 @@ test.suite(
         }
       );
       expect(err).toBe(null);
-      expect(stdout).toBe('0\n');
+      expect(stdout).toBe('{ esm: true }\n');
     });
   }
 );

--- a/src/test/module-node/1778.spec.ts
+++ b/src/test/module-node/1778.spec.ts
@@ -19,7 +19,11 @@ const test = context(ctxTsNode);
 test.suite(
   'Issue #1778: typechecker resolver should take importer\'s module type -- cjs or esm -- into account when resolving package.json "exports"',
   (test) => {
-    test.runIf(nodeSupportsEsmHooks && nodeSupportsSpawningChildProcess && tsSupportsStableNodeNextNode16);
+    test.runIf(
+      nodeSupportsEsmHooks &&
+        nodeSupportsSpawningChildProcess &&
+        tsSupportsStableNodeNextNode16
+    );
     test('test', async () => {
       const { err, stdout } = await exec(
         `${CMD_TS_NODE_WITHOUT_PROJECT_FLAG} ./index.ts`,

--- a/src/test/module-node/module-node.spec.ts
+++ b/src/test/module-node/module-node.spec.ts
@@ -1,15 +1,15 @@
-import { expect, context } from './testlib';
+import { expect, context } from '../testlib';
 import {
   CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
   isOneOf,
   nodeSupportsImportingTransformedCjsFromEsm,
   resetNodeEnvironment,
   tsSupportsStableNodeNextNode16,
-} from './helpers';
+} from '../helpers';
 import * as Path from 'path';
-import { ctxTsNode } from './helpers';
-import { exec } from './exec-helpers';
-import { file, project, ProjectAPI as ProjectAPI } from './fs-helpers';
+import { ctxTsNode } from '../helpers';
+import { exec } from '../exec-helpers';
+import { file, project, ProjectAPI as ProjectAPI } from '../fs-helpers';
 
 const test = context(ctxTsNode);
 test.beforeEach(async () => {

--- a/src/ts-compiler-types.ts
+++ b/src/ts-compiler-types.ts
@@ -79,6 +79,12 @@ export namespace TSCommon {
       ? typeof _ts.ModuleKind['Node16']
       : 100;
   };
+  // Can't figure out how to re-export an enum
+  // `export import ... =` complains that _ts is type-only import
+  export namespace ModuleKind {
+    export type CommonJS = _ts.ModuleKind.CommonJS;
+    export type ESNext = _ts.ModuleKind.ESNext;
+  }
 }
 
 /**

--- a/src/ts-compiler-types.ts
+++ b/src/ts-compiler-types.ts
@@ -32,16 +32,7 @@ export interface TSCommon {
   createModuleResolutionCache: typeof _ts.createModuleResolutionCache;
   resolveModuleName: typeof _ts.resolveModuleName;
   resolveModuleNameFromCache: typeof _ts.resolveModuleNameFromCache;
-  // Changed in TS 4.7
-  resolveTypeReferenceDirective(
-    typeReferenceDirectiveName: string,
-    containingFile: string | undefined,
-    options: _ts.CompilerOptions,
-    host: _ts.ModuleResolutionHost,
-    redirectedReference?: _ts.ResolvedProjectReference,
-    cache?: _ts.TypeReferenceDirectiveResolutionCache,
-    resolutionMode?: _ts.SourceFile['impliedNodeFormat']
-  ): _ts.ResolvedTypeReferenceDirectiveWithFailedLookupLocations;
+  resolveTypeReferenceDirective: typeof _ts.resolveTypeReferenceDirective;
   createIncrementalCompilerHost: typeof _ts.createIncrementalCompilerHost;
   createSourceFile: typeof _ts.createSourceFile;
   getDefaultLibFileName: typeof _ts.getDefaultLibFileName;
@@ -52,16 +43,7 @@ export interface TSCommon {
   ModuleResolutionKind: typeof _ts.ModuleResolutionKind;
 }
 export namespace TSCommon {
-  export interface LanguageServiceHost extends _ts.LanguageServiceHost {
-    // Modified in 4.7
-    resolveTypeReferenceDirectives?(
-      typeDirectiveNames: string[] | _ts.FileReference[],
-      containingFile: string,
-      redirectedReference: _ts.ResolvedProjectReference | undefined,
-      options: _ts.CompilerOptions,
-      containingFileMode?: _ts.SourceFile['impliedNodeFormat'] | undefined
-    ): (_ts.ResolvedTypeReferenceDirective | undefined)[];
-  }
+  export interface LanguageServiceHost extends _ts.LanguageServiceHost {}
   export type ModuleResolutionHost = _ts.ModuleResolutionHost;
   export type ParsedCommandLine = _ts.ParsedCommandLine;
   export type ResolvedModule = _ts.ResolvedModule;

--- a/src/ts-compiler-types.ts
+++ b/src/ts-compiler-types.ts
@@ -118,7 +118,10 @@ export interface TSInternal {
     usage: 'files' | 'directories' | 'exclude'
   ): string | undefined;
   // Added in TS 4.7
-  getModeForResolutionAtIndex?(file: TSInternal.SourceFileImportsList, index: number): _ts.SourceFile['impliedNodeFormat'];
+  getModeForResolutionAtIndex?(
+    file: TSInternal.SourceFileImportsList,
+    index: number
+  ): _ts.SourceFile['impliedNodeFormat'];
 }
 /** @internal */
 export namespace TSInternal {
@@ -131,6 +134,6 @@ export namespace TSInternal {
   }
   // Note: is only a partial declaration, TS sources declare other fields
   export interface SourceFileImportsList {
-    impliedNodeFormat?: TSCommon.SourceFile["impliedNodeFormat"];
-};
+    impliedNodeFormat?: TSCommon.SourceFile['impliedNodeFormat'];
+  }
 }

--- a/src/ts-compiler-types.ts
+++ b/src/ts-compiler-types.ts
@@ -117,6 +117,8 @@ export interface TSInternal {
     basePath: string,
     usage: 'files' | 'directories' | 'exclude'
   ): string | undefined;
+  // Added in TS 4.7
+  getModeForResolutionAtIndex?(file: TSInternal.SourceFileImportsList, index: number): _ts.SourceFile['impliedNodeFormat'];
 }
 /** @internal */
 export namespace TSInternal {
@@ -127,4 +129,8 @@ export namespace TSInternal {
     getCurrentDirectory(): string;
     useCaseSensitiveFileNames: boolean;
   }
+  // Note: is only a partial declaration, TS sources declare other fields
+  export interface SourceFileImportsList {
+    impliedNodeFormat?: TSCommon.SourceFile["impliedNodeFormat"];
+};
 }

--- a/tests/1778/index.ts
+++ b/tests/1778/index.ts
@@ -1,0 +1,6 @@
+import foo from 'foo';
+
+// This file is ESM, so if typechecker's resolver is working correctly, will
+// resolve to the foo's package.json "exports" mapping for "default", not "require"
+const bar: { esm: true } = foo;
+console.log(bar);

--- a/tests/1778/node_modules/foo/cjs/index.d.ts
+++ b/tests/1778/node_modules/foo/cjs/index.d.ts
@@ -1,0 +1,2 @@
+declare const foo: {cjs: true}
+export default foo

--- a/tests/1778/node_modules/foo/cjs/index.js
+++ b/tests/1778/node_modules/foo/cjs/index.js
@@ -1,0 +1,1 @@
+module.exports = {cjs: true}

--- a/tests/1778/node_modules/foo/cjs/package.json
+++ b/tests/1778/node_modules/foo/cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/tests/1778/node_modules/foo/esm/index.d.ts
+++ b/tests/1778/node_modules/foo/esm/index.d.ts
@@ -1,0 +1,2 @@
+declare const foo: {esm: true}
+export default foo

--- a/tests/1778/node_modules/foo/esm/index.js
+++ b/tests/1778/node_modules/foo/esm/index.js
@@ -1,0 +1,1 @@
+export default {esm: true}

--- a/tests/1778/node_modules/foo/package.json
+++ b/tests/1778/node_modules/foo/package.json
@@ -1,0 +1,9 @@
+{
+  "type": "module",
+  "exports": {
+    ".": {
+      "require": "./cjs/index.js",
+      "default": "./esm/index.js"
+    }
+  }
+}

--- a/tests/1778/package.json
+++ b/tests/1778/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/1778/tsconfig.json
+++ b/tests/1778/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "ts-node": {
+    "esm": true
+  },
+  "compilerOptions": {
+    "module": "NodeNext",
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Fixes #1778

Pending feedback on Discord, hoping to get some guidance on my use of `impliedNodeFormat`
https://discord.com/channels/508357248330760243/640177429775777792/981402019598315520