### PR TITLE
Allow JSON imports in NodeJS 16.15

### DIFF
--- a/dist-raw/node-internal-modules-esm-get_format.js
+++ b/dist-raw/node-internal-modules-esm-get_format.js
@@ -12,6 +12,7 @@ const [nodeMajor, nodeMinor] = process.versions.node.split('.').map(s => parseIn
 const experimentalJsonModules =
   nodeMajor > 17
   || (nodeMajor === 17 && nodeMinor >= 5)
+  || (nodeMajor === 16 && nodeMinor >= 15)
   || getOptionValue('--experimental-json-modules');
 const experimentalWasmModules = getOptionValue('--experimental-wasm-modules');
 const { URL, fileURLToPath } = require('url');

--- a/src/test/esm-loader.spec.ts
+++ b/src/test/esm-loader.spec.ts
@@ -20,6 +20,8 @@ import {
   nodeUsesNewHooksApi,
   resetNodeEnvironment,
   TEST_DIR,
+  tsSupportsImportAssertions,
+  tsSupportsResolveJsonModule,
 } from './helpers';
 import { createExec, createSpawn, ExecReturn } from './exec-helpers';
 import { join, resolve } from 'path';
@@ -269,7 +271,11 @@ test.suite('esm', (test) => {
     });
 
     test.suite('supports import assertions', (test) => {
-      test.runIf(nodeSupportsImportAssertions);
+      test.runIf(
+        nodeSupportsImportAssertions &&
+          tsSupportsImportAssertions &&
+          tsSupportsResolveJsonModule
+      );
 
       const macro = test.macro((flags: string) => async (t) => {
         const { err, stdout } = await exec(

--- a/src/test/esm-loader.spec.ts
+++ b/src/test/esm-loader.spec.ts
@@ -15,6 +15,7 @@ import {
   EXPERIMENTAL_MODULES_FLAG,
   nodeSupportsEsmHooks,
   nodeSupportsImportAssertions,
+  nodeSupportsImportAssertionsTypeJson,
   nodeSupportsSpawningChildProcess,
   nodeUsesNewHooksApi,
   resetNodeEnvironment,
@@ -270,8 +271,8 @@ test.suite('esm', (test) => {
     test.suite('supports import assertions', (test) => {
       test.runIf(nodeSupportsImportAssertions);
 
-      test.suite('node >=17.5.0', (test) => {
-        test.runIf(semver.gte(process.version, '17.5.0'));
+      test.suite('node >=16.15.0 <17.0.0 | >=17.5.0', (test) => {
+        test.runIf(nodeSupportsImportAssertionsTypeJson);
 
         test('Can import JSON modules with appropriate assertion', async (t) => {
           const { err, stdout } = await exec(
@@ -287,8 +288,8 @@ test.suite('esm', (test) => {
         });
       });
 
-      test.suite('node <17.5.0', (test) => {
-        test.runIf(semver.lt(process.version, '17.5.0'));
+      test.suite('node <16.15.0 | 17.0.0> <17.5.0', (test) => {
+        test.runIf(!nodeSupportsImportAssertionsTypeJson);
 
         test('Can import JSON using the appropriate flag and assertion', async (t) => {
           const { err, stdout } = await exec(

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -64,12 +64,14 @@ export const nodeSupportsSpawningChildProcess = semver.gte(
   '12.17.0'
 );
 export const nodeUsesNewHooksApi = semver.gte(process.version, '16.12.0');
-export const nodeSupportsImportAssertions = semver.gte(process.version, '16.14.0') &&
-        semver.lt(process.version, '17.0.0') ||
-        semver.gte(process.version, '17.1.0');
-export const nodeSupportsImportAssertionsTypeJson = semver.gte(process.version, '16.15.0') &&
-        semver.lt(process.version, '17.0.0') ||
-        semver.gte(process.version, '17.5.0');
+export const nodeSupportsImportAssertions =
+  (semver.gte(process.version, '16.14.0') &&
+    semver.lt(process.version, '17.0.0')) ||
+  semver.gte(process.version, '17.1.0');
+export const nodeSupportsImportAssertionsTypeJson =
+  (semver.gte(process.version, '16.15.0') &&
+    semver.lt(process.version, '17.0.0')) ||
+  semver.gte(process.version, '17.5.0');
 // Node 14.13.0 has a bug where it tries to lex CJS files to discover named exports *before*
 // we transform the code.
 // In other words, it tries to parse raw TS as CJS and balks at `export const foo =`, expecting to see `exports.foo =`

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -64,11 +64,16 @@ export const nodeSupportsSpawningChildProcess = semver.gte(
   '12.17.0'
 );
 export const nodeUsesNewHooksApi = semver.gte(process.version, '16.12.0');
+// 16.14.0: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#notable-changes-4
+// 17.1.0: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#2021-11-09-version-1710-current-targos
 export const nodeSupportsImportAssertions =
   (semver.gte(process.version, '16.14.0') &&
     semver.lt(process.version, '17.0.0')) ||
   semver.gte(process.version, '17.1.0');
-export const nodeSupportsImportAssertionsTypeJson =
+// These versions do not require `--experimental-json-modules`
+// 16.15.0: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V16.md#2022-04-26-version-16150-gallium-lts-danielleadams
+// 17.5.0: https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V17.md#2022-02-10-version-1750-current-ruyadorno
+export const nodeSupportsUnflaggedJsonImports =
   (semver.gte(process.version, '16.15.0') &&
     semver.lt(process.version, '17.0.0')) ||
   semver.gte(process.version, '17.5.0');

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -85,6 +85,7 @@ export const nodeSupportsImportingTransformedCjsFromEsm = semver.gte(
   process.version,
   '14.13.1'
 );
+export const tsSupportsResolveJsonModule = semver.gte(ts.version, '2.9.0');
 /** Supports tsconfig "extends" >= v3.2.0 */
 export const tsSupportsTsconfigInheritanceViaNodePackages = semver.gte(
   ts.version,
@@ -97,6 +98,7 @@ export const tsSupportsStableNodeNextNode16 =
   ts.version.startsWith('4.7.') || semver.gte(ts.version, '4.7.0');
 // TS 4.5 is first version to understand .cts, .mts, .cjs, and .mjs extensions
 export const tsSupportsMtsCtsExtensions = semver.gte(ts.version, '4.5.0');
+export const tsSupportsImportAssertions = semver.gte(ts.version, '4.5.0');
 //#endregion
 
 export const xfs = new NodeFS(fs);

--- a/src/test/helpers.ts
+++ b/src/test/helpers.ts
@@ -64,10 +64,12 @@ export const nodeSupportsSpawningChildProcess = semver.gte(
   '12.17.0'
 );
 export const nodeUsesNewHooksApi = semver.gte(process.version, '16.12.0');
-export const nodeSupportsImportAssertions = semver.gte(
-  process.version,
-  '17.1.0'
-);
+export const nodeSupportsImportAssertions = semver.gte(process.version, '16.14.0') &&
+        semver.lt(process.version, '17.0.0') ||
+        semver.gte(process.version, '17.1.0');
+export const nodeSupportsImportAssertionsTypeJson = semver.gte(process.version, '16.15.0') &&
+        semver.lt(process.version, '17.0.0') ||
+        semver.gte(process.version, '17.5.0');
 // Node 14.13.0 has a bug where it tries to lex CJS files to discover named exports *before*
 // we transform the code.
 // In other words, it tries to parse raw TS as CJS and balks at `export const foo =`, expecting to see `exports.foo =`


### PR DESCRIPTION
This PR is a quick fix that enables JSON module support by default in NodeJS v16.15 < v17 as well as v17.5 and up.  The version number was selected based upon [prior manual testing](https://github.com/mdn/browser-compat-data/pull/16413) to determine when JSON module support was enabled by default.

This change was tested by attempting to run a script that uses a JSON import and performing the same tweak directly in `node_modules`.