### PR TITLE
swc: Support paths from tsconfig

### DIFF
--- a/src/test/transpilers.spec.ts
+++ b/src/test/transpilers.spec.ts
@@ -3,13 +3,23 @@
 // Should consolidate them here.
 
 import { context } from './testlib';
-import { ctxTsNode, testsDirRequire } from './helpers';
+import {
+  CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
+  ctxTsNode,
+  TEST_DIR,
+  testsDirRequire,
+} from './helpers';
 import * as expect from 'expect';
+import { createExec } from './exec-helpers';
+
+const exec = createExec({
+  cwd: TEST_DIR,
+});
 
 const test = context(ctxTsNode);
 
 test.suite('swc', (test) => {
-  test('verify that TS->SWC target mappings suppport all possible values from both TS and SWC', async (t) => {
+  test('verify that TS->SWC target mappings support all possible values from both TS and SWC', async (t) => {
     const swcTranspiler = testsDirRequire(
       'ts-node/transpilers/swc-experimental'
     ) as typeof import('../transpilers/swc');
@@ -43,5 +53,19 @@ test.suite('swc', (test) => {
     for (const target of targets) {
       expect([...swcTranspiler.targetMapping.values()]).toContain(target);
     }
+  });
+
+  test('verify paths are mapped correctly', async (t) => {
+    const { err, stdout } = await exec(
+      `${CMD_TS_NODE_WITHOUT_PROJECT_FLAG} swc-with-paths`,
+      {
+        env: {
+          ...process.env,
+          NODE_OPTIONS: `${process.env.NODE_OPTIONS || ''}}`,
+        },
+      }
+    );
+    expect(err).toBe(null);
+    expect(stdout).toMatch('Hello, world!\n');
   });
 });

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import type * as ts from 'typescript';
 import type * as swcWasm from '@swc/wasm';
 import type * as swcTypes from '@swc/core';
@@ -60,6 +61,8 @@ export function create(createOptions: SwcTranspilerOptions): Transpiler {
     strict,
     alwaysStrict,
     noImplicitUseStrict,
+    baseUrl,
+    paths,
   } = compilerOptions;
   const nonTsxOptions = createSwcOptions(false);
   const tsxOptions = createSwcOptions(true);
@@ -110,6 +113,16 @@ export function create(createOptions: SwcTranspilerOptions): Transpiler {
       noImplicitUseStrict === true
         ? false
         : true;
+
+    const absolutePaths = Object.fromEntries(
+      Object.entries(paths || {})
+        .filter(([key, values]) => values.length > 0)
+        .map(([key, values]) => [
+          key,
+          values.map((value) => path.resolve(baseUrl || './', value)),
+        ])
+    ) as { [from: string]: [string] };
+
     return {
       sourceMaps: sourceMap,
       // isModule: true,
@@ -144,6 +157,9 @@ export function create(createOptions: SwcTranspilerOptions): Transpiler {
           } as swcTypes.ReactConfig,
         },
         keepClassNames,
+        baseUrl,
+        paths:
+          Object.keys(absolutePaths).length > 0 ? absolutePaths : undefined,
       } as swcTypes.JscConfig,
     };
   }

--- a/tests/swc-with-paths/index.ts
+++ b/tests/swc-with-paths/index.ts
@@ -1,0 +1,1 @@
+import '@parent-dir/hello-world';

--- a/tests/swc-with-paths/tsconfig.json
+++ b/tests/swc-with-paths/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "ts-node": {
+    "swc": true
+  },
+  "compilerOptions": {
+    "module": "CommonJS",
+    "baseUrl": "./",
+    "paths": {
+      "@parent-dir/*": ["../*"]
+    }
+  }
+}


### PR DESCRIPTION
The swc transpiler can support paths, but they have to be converted to absolute paths using the baseUrl first.