### PR TITLE
Revert "Use file URL for source map paths (#1771)"

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-import { relative, basename, extname, dirname, join, isAbsolute } from 'path';
+import { relative, basename, extname, dirname, join } from 'path';
 import { Module } from 'module';
 import * as util from 'util';
-import { fileURLToPath, pathToFileURL } from 'url';
+import { fileURLToPath } from 'url';
 
 import type * as _sourceMapSupport from '@cspotcode/source-map-support';
 import { BaseError } from 'make-error';
@@ -1667,11 +1667,8 @@ function updateOutput(
  */
 function updateSourceMap(sourceMapText: string, fileName: string) {
   const sourceMap = JSON.parse(sourceMapText);
-  const outputFileName = isAbsolute(fileName)
-    ? pathToFileURL(fileName).href
-    : fileName;
-  sourceMap.file = outputFileName;
-  sourceMap.sources = [outputFileName];
+  sourceMap.file = fileName;
+  sourceMap.sources = [fileName];
   delete sourceMap.sourceRoot;
   return JSON.stringify(sourceMap);
 }


### PR DESCRIPTION
Revert #1771 

Fixes #1797 and #1790

@PaperStrike if we choose to implement #1769 in the future, it'll need a bit more work to:

a) prove that we are fixing a real-world use-case, not merely an academic desire to comply with a spec
b) prove that debugging scenarios continue to work.  Will likely require automated testing of:
  - VSCode debugging
  - code coverage via nyc
  - code coverage via c8 which, in turn, uses node's native coverage mechanism