### PR TITLE
Fix #1764: `evalCode` should always persist into the virtual sourcefile

### DIFF
--- a/src/repl.ts
+++ b/src/repl.ts
@@ -207,6 +207,7 @@ export function createRepl(options: CreateReplOptions = {}) {
       state,
       input: code,
       context,
+      overrideIsCompletion: false,
     });
     assert(result.containsTopLevelAwait === false);
     return result.value;
@@ -512,6 +513,12 @@ function appendCompileAndEvalInput(options: {
   /** Enable top-level await but only if the TSNode service allows it. */
   enableTopLevelAwait?: boolean;
   context: Context | undefined;
+  /**
+   * Added so that `evalCode` can be guaranteed *not* to trigger the `isCompletion`
+   * codepath.  However, the `isCompletion` logic is ancient and maybe should be removed entirely.
+   * Nobody's looked at it in a long time.
+   */
+  overrideIsCompletion?: boolean;
 }): AppendCompileAndEvalInputResult {
   const {
     service,
@@ -519,6 +526,7 @@ function appendCompileAndEvalInput(options: {
     wrappedErr,
     enableTopLevelAwait = false,
     context,
+    overrideIsCompletion,
   } = options;
   let { input } = options;
 
@@ -533,7 +541,7 @@ function appendCompileAndEvalInput(options: {
   }
 
   const lines = state.lines;
-  const isCompletion = !/\n$/.test(input);
+  const isCompletion = overrideIsCompletion ?? !/\n$/.test(input);
   const undo = appendToEvalState(state, input);
   let output: string;
 


### PR DESCRIPTION
Fixes #1764