### PR TITLE
[Docs] Clarify programmatic usage with ESM support

### DIFF
--- a/website/docs/usage.md
+++ b/website/docs/usage.md
@@ -85,4 +85,6 @@ node --loader ts-node/esm --inspect ./index.ts
 
 You can require ts-node and register the loader for future requires by using `require('ts-node').register({ /* options */ })`.
 
+Note that this does not support ESM, node currently does not offer a way to programmatically add hooks when using ES modules. If you want to programmatically use ts-node with ESM support you need to write your own module loader which wraps ts-node and then invoke it in one of the ways described above.
+
 Check out our [API](./api.md) for more features.


### PR DESCRIPTION
Add clarification that ESM is not supported in programmatic usage due to a limitation on node's side.
See this discussion: https://github.com/TypeStrong/ts-node/discussions/1798

Because I just lost a good hour getting this to work before I found the discussion I added a change to the docs here to make this clearer.

Hope this is helpful, if it needs changes let me know.