### PR TITLE
Fix typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,7 +122,7 @@ We publish using `np`: https://npm.im/np
 4. Publish with `np`
  - `np --branch main --no-tests`
   - `--no-tests` because we must rely on CI to test ts-node.  Even if you *did* run the tests locally, you would only be testing a single operating system, node version, and TypeScript version, so locally-run tests are insufficient.
-5. Add changelog to the Github Release; match formatting from previous releases
+5. Add changelog to the GitHub Release; match formatting from previous releases
 6. Move `docs` branch to head of `main`
   - this rebuilds the website
   - `git push --force origin main:docs`

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ You can build the readme with this command:
 
 # [![TypeScript Node](logo.svg?sanitize=true)](https://typestrong.org/ts-node)
 
-[![NPM version](https://img.shields.io/npm/v/ts-node.svg?style=flat)](https://npmjs.org/package/ts-node)
-[![NPM downloads](https://img.shields.io/npm/dm/ts-node.svg?style=flat)](https://npmjs.org/package/ts-node)
+[![npm version](https://img.shields.io/npm/v/ts-node.svg?style=flat)](https://npmjs.org/package/ts-node)
+[![npm downloads](https://img.shields.io/npm/dm/ts-node.svg?style=flat)](https://npmjs.org/package/ts-node)
 [![Build status](https://img.shields.io/github/actions/workflow/status/TypeStrong/ts-node/continuous-integration.yml?branch=main)](https://github.com/TypeStrong/ts-node/actions?query=workflow%3A%22Continuous+Integration%22)
 [![Test coverage](https://codecov.io/gh/TypeStrong/ts-node/branch/main/graph/badge.svg)](https://codecov.io/gh/TypeStrong/ts-node)
 
@@ -121,7 +121,7 @@ The latest documentation can also be found on our website: <https://typestrong.o
         *   [CommonJS](#commonjs-1)
         *   [Native ECMAScript modules](#native-ecmascript-modules-1)
     *   [Gulp](#gulp)
-    *   [IntelliJ and Webstorm](#intellij-and-webstorm)
+    *   [IntelliJ and WebStorm](#intellij-and-webstorm)
     *   [Mocha](#mocha)
         *   [Mocha 7 and newer](#mocha-7-and-newer)
         *   [Mocha <=6](#mocha-6)
@@ -1346,7 +1346,7 @@ gulp
 
 See also: https://gulpjs.com/docs/en/getting-started/javascript-and-gulpfiles#transpilation
 
-## IntelliJ and Webstorm
+## IntelliJ and WebStorm
 
 Create a new Node.js configuration and add `-r ts-node/register` to "Node parameters."
 

--- a/api-extractor.json
+++ b/api-extractor.json
@@ -9,7 +9,7 @@
    * standard settings to be shared across multiple projects.
    *
    * If the path starts with "./" or "../", the path is resolved relative to the folder of the file that contains
-   * the "extends" field.  Otherwise, the first path segment is interpreted as an NPM package name, and will be
+   * the "extends" field.  Otherwise, the first path segment is interpreted as an npm package name, and will be
    * resolved using NodeJS require().
    *
    * SUPPORTED TOKENS: none
@@ -48,10 +48,10 @@
   "mainEntryPointFilePath": "<projectFolder>/dist/index.d.ts",
 
   /**
-   * A list of NPM package names whose exports should be treated as part of this package.
+   * A list of npm package names whose exports should be treated as part of this package.
    *
    * For example, suppose that Webpack is used to generate a distributed bundle for the project "library1",
-   * and another NPM package "library2" is embedded in this bundle.  Some types from library2 may become part
+   * and another npm package "library2" is embedded in this bundle.  Some types from library2 may become part
    * of the exported API for library1, but by default API Extractor would generate a .d.ts rollup that explicitly
    * imports library2.  To avoid this, we can specify:
    *

--- a/development-docs/release-template.md
+++ b/development-docs/release-template.md
@@ -3,7 +3,7 @@
 ---
 
 <!--
-  I don't make a discussion thread for every release.  Github has a button to make a discussion thread for a release.
+  I don't make a discussion thread for every release.  GitHub has a button to make a discussion thread for a release.
   Then I update the discussion thread to remove the release notes and instead link to the release.
 -->
 Questions about this release? Ask in the official discussion thread: #TODO

--- a/website/docs/recipes/intellij.md
+++ b/website/docs/recipes/intellij.md
@@ -1,5 +1,5 @@
 ---
-title: "IntelliJ and Webstorm"
+title: "IntelliJ and WebStorm"
 ---
 
 Create a new Node.js configuration and add `-r ts-node/register` to "Node parameters."

--- a/website/readme-sources/prefix.md
+++ b/website/readme-sources/prefix.md
@@ -16,8 +16,8 @@ You can build the readme with this command:
 
 # [![TypeScript Node](logo.svg?sanitize=true)](https://typestrong.org/ts-node)
 
-[![NPM version](https://img.shields.io/npm/v/ts-node.svg?style=flat)](https://npmjs.org/package/ts-node)
-[![NPM downloads](https://img.shields.io/npm/dm/ts-node.svg?style=flat)](https://npmjs.org/package/ts-node)
+[![npm version](https://img.shields.io/npm/v/ts-node.svg?style=flat)](https://npmjs.org/package/ts-node)
+[![npm downloads](https://img.shields.io/npm/dm/ts-node.svg?style=flat)](https://npmjs.org/package/ts-node)
 [![Build status](https://img.shields.io/github/actions/workflow/status/TypeStrong/ts-node/continuous-integration.yml?branch=main)](https://github.com/TypeStrong/ts-node/actions?query=workflow%3A%22Continuous+Integration%22)
 [![Test coverage](https://codecov.io/gh/TypeStrong/ts-node/branch/main/graph/badge.svg)](https://codecov.io/gh/TypeStrong/ts-node)
 


### PR DESCRIPTION
Just a couple of minor capitalization fixes.

Also see: [npm should never be capitalized](https://github.com/npm/cli#is-it-npm-or-npm-or-npm)
