### PR TITLE
Fix bug where REPL inputs were compiled as ESM in ESM projects

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -517,7 +517,8 @@ function phase4(payload: BootstrapState) {
     module.paths = (Module as any)._nodeModulePaths(cwd);
   }
   if (executeRepl) {
-    const state = new EvalState(join(cwd, REPL_FILENAME));
+    // correct path is set later
+    const state = new EvalState('');
     replStuff = {
       state,
       repl: createRepl({
@@ -541,6 +542,10 @@ function phase4(payload: BootstrapState) {
     },
   });
   register(service);
+
+  if (replStuff)
+    replStuff.state.path = join(cwd, REPL_FILENAME(service.ts.version));
+
   if (isInChildProcess)
     (
       require('./child/child-loader') as typeof import('./child/child-loader')

--- a/src/file-extensions.ts
+++ b/src/file-extensions.ts
@@ -50,6 +50,10 @@ const nodeDoesNotUnderstand: readonly string[] = [
   '.mts',
 ];
 
+export function tsSupportsMtsCtsExts(tsVersion: string) {
+  return versionGteLt(tsVersion, '4.5.0');
+}
+
 /**
  * [MUST_UPDATE_FOR_NEW_FILE_EXTENSIONS]
  * @internal
@@ -60,7 +64,7 @@ export function getExtensions(
   tsVersion: string
 ) {
   // TS 4.5 is first version to understand .cts, .mts, .cjs, and .mjs extensions
-  const tsSupportsMtsCtsExts = versionGteLt(tsVersion, '4.5.0');
+  const supportMtsCtsExts = tsSupportsMtsCtsExts(tsVersion);
 
   const requiresHigherTypescriptVersion: string[] = [];
   if (!tsSupportsMtsCtsExts)
@@ -78,11 +82,11 @@ export function getExtensions(
   const compiledJsxUnsorted: string[] = [];
 
   if (config.options.jsx) compiledJsxUnsorted.push('.tsx');
-  if (tsSupportsMtsCtsExts) compiledJsUnsorted.push('.mts', '.cts');
+  if (supportMtsCtsExts) compiledJsUnsorted.push('.mts', '.cts');
   if (config.options.allowJs) {
     compiledJsUnsorted.push('.js');
     if (config.options.jsx) compiledJsxUnsorted.push('.jsx');
-    if (tsSupportsMtsCtsExts) compiledJsUnsorted.push('.mjs', '.cjs');
+    if (supportMtsCtsExts) compiledJsUnsorted.push('.mjs', '.cjs');
   }
 
   const compiledUnsorted = [...compiledJsUnsorted, ...compiledJsxUnsorted];

--- a/src/repl.ts
+++ b/src/repl.ts
@@ -43,7 +43,7 @@ export const STDIN_FILENAME = `[stdin].ts`;
 /** @internal */
 export const STDIN_NAME = `[stdin]`;
 /** @internal */
-export const REPL_FILENAME = '<repl>.ts';
+export const REPL_FILENAME = '<repl>.cts';
 /** @internal */
 export const REPL_NAME = '<repl>';
 

--- a/src/test/helpers/ctx-ts-node.ts
+++ b/src/test/helpers/ctx-ts-node.ts
@@ -39,6 +39,7 @@ export async function installTsNode() {
     while (true) {
       try {
         rimrafSync(join(TEST_DIR, '.yarn/cache/ts-node-file-*'));
+        writeFileSync(join(TEST_DIR, 'yarn.lock'), '');
         const result = await promisify(childProcessExec)(
           `yarn --no-immutable`,
           {

--- a/src/test/repl/helpers/ctx-repl.ts
+++ b/src/test/repl/helpers/ctx-repl.ts
@@ -1,8 +1,9 @@
-import { PassThrough } from 'stream';
-import { delay, TEST_DIR, tsNodeTypes, ctxTsNode } from '../helpers';
-import type { ExecutionContext } from 'ava';
-import { test, expect } from '../testlib';
+import type { ExecutionContext } from '@cspotcode/ava-lib';
 import { expectStream } from '@cspotcode/expect-stream';
+import { PassThrough } from 'stream';
+import type { ctxTsNode } from '../../helpers/ctx-ts-node';
+import { delay, tsNodeTypes } from '../../helpers/misc';
+import { TEST_DIR } from '../../helpers/paths';
 
 export interface CreateReplViaApiOptions {
   registerHooks: boolean;
@@ -96,47 +97,4 @@ export async function ctxRepl(t: ctxTsNode.T) {
       stderr: await stderrPromise,
     };
   }
-}
-
-export const macroReplNoErrorsAndStdoutContains = test.macro(
-  (script: string, contains: string, options?: Partial<ExecuteInReplOptions>) =>
-    async (t: ctxRepl.T) => {
-      macroReplInternal(t, script, contains, undefined, contains, options);
-    }
-);
-export const macroReplStderrContains = test.macro(
-  (
-      script: string,
-      errorContains: string,
-      options?: Partial<ExecuteInReplOptions>
-    ) =>
-    async (t: ctxRepl.T) => {
-      macroReplInternal(
-        t,
-        script,
-        undefined,
-        errorContains,
-        errorContains,
-        options
-      );
-    }
-);
-
-async function macroReplInternal(
-  t: ctxRepl.T,
-  script: string,
-  stdoutContains: string | undefined,
-  stderrContains: string | undefined,
-  waitPattern: string,
-  options?: Partial<ExecuteInReplOptions>
-) {
-  const r = await t.context.executeInRepl(script, {
-    registerHooks: true,
-    startInternalOptions: { useGlobal: false },
-    waitPattern,
-    ...options,
-  });
-  if (stderrContains) expect(r.stderr).toContain(stderrContains);
-  else expect(r.stderr).toBe('');
-  if (stdoutContains) expect(r.stdout).toContain(stdoutContains);
 }

--- a/src/test/repl/helpers/macros.ts
+++ b/src/test/repl/helpers/macros.ts
@@ -1,0 +1,45 @@
+import type { ctxRepl, ExecuteInReplOptions } from './ctx-repl';
+import { expect, test } from '../../testlib';
+
+export const macroReplNoErrorsAndStdoutContains = test.macro(
+  (script: string, contains: string, options?: Partial<ExecuteInReplOptions>) =>
+    async (t: ctxRepl.T) => {
+      macroReplInternal(t, script, contains, undefined, contains, options);
+    }
+);
+export const macroReplStderrContains = test.macro(
+  (
+      script: string,
+      errorContains: string,
+      options?: Partial<ExecuteInReplOptions>
+    ) =>
+    async (t: ctxRepl.T) => {
+      macroReplInternal(
+        t,
+        script,
+        undefined,
+        errorContains,
+        errorContains,
+        options
+      );
+    }
+);
+
+async function macroReplInternal(
+  t: ctxRepl.T,
+  script: string,
+  stdoutContains: string | undefined,
+  stderrContains: string | undefined,
+  waitPattern: string,
+  options?: Partial<ExecuteInReplOptions>
+) {
+  const r = await t.context.executeInRepl(script, {
+    registerHooks: true,
+    startInternalOptions: { useGlobal: false },
+    waitPattern,
+    ...options,
+  });
+  if (stderrContains) expect(r.stderr).toContain(stderrContains);
+  else expect(r.stderr).toBe('');
+  if (stdoutContains) expect(r.stdout).toContain(stdoutContains);
+}

--- a/src/test/repl/helpers/misc.ts
+++ b/src/test/repl/helpers/misc.ts
@@ -1,0 +1,3 @@
+import { tsNodeTypes, tsSupportsMtsCtsExtensions } from '../../helpers';
+
+export const replFile = tsSupportsMtsCtsExtensions ? '<repl>.cts' : '<repl>.ts';

--- a/src/test/repl/repl-environment.spec.ts
+++ b/src/test/repl/repl-environment.spec.ts
@@ -14,7 +14,8 @@ import {
 import { dirname, join } from 'path';
 import { createExec, createExecTester } from '../exec-helpers';
 import { homedir } from 'os';
-import { ctxRepl } from './helpers';
+import { replFile } from './helpers/misc';
+import { ctxRepl } from './helpers/ctx-repl';
 
 const test = context(ctxTsNode).contextEach(ctxRepl);
 
@@ -197,7 +198,7 @@ test.suite(
           exportsTest: true,
           // Note: vanilla node uses different name. See #1360
           stackTest: expect.stringContaining(
-            `    at ${join(TEST_DIR, '<repl>.cts')}:4:`
+            `    at ${join(TEST_DIR, replFile)}:4:`
           ),
           moduleAccessorsTest: true,
           argv: [tsNodeExe],
@@ -350,7 +351,7 @@ test.suite(
           exportsTest: true,
           // Note: vanilla node uses different name. See #1360
           stackTest: expect.stringContaining(
-            `    at ${join(TEST_DIR, '<repl>.cts')}:4:`
+            `    at ${join(TEST_DIR, replFile)}:4:`
           ),
           moduleAccessorsTest: true,
           argv: [tsNodeExe],
@@ -428,7 +429,7 @@ test.suite(
 
             // Note: vanilla node uses different name. See #1360
             stackTest: expect.stringContaining(
-              `    at ${join(TEST_DIR, '<repl>.cts')}:1:`
+              `    at ${join(TEST_DIR, replFile)}:1:`
             ),
           },
         });
@@ -459,7 +460,7 @@ test.suite(
             exportsTest: true,
             // Note: vanilla node uses different name. See #1360
             stackTest: expect.stringContaining(
-              `    at ${join(TEST_DIR, '<repl>.cts')}:1:`
+              `    at ${join(TEST_DIR, replFile)}:1:`
             ),
             moduleAccessorsTest: true,
           },

--- a/src/test/repl/repl-environment.spec.ts
+++ b/src/test/repl/repl-environment.spec.ts
@@ -100,7 +100,7 @@ test.suite(
               modulePath: typeof module !== 'undefined' && module.path,
               moduleFilename: typeof module !== 'undefined' && module.filename,
               modulePaths: typeof module !== 'undefined' && [...module.paths],
-              exportsTest: typeof exports !== 'undefined' ? module.exports === exports : null,
+              exportsTest: typeof exports !== 'undefined' && typeof module !== 'undefined' ? module.exports === exports : null,
               stackTest: new Error().stack!.split('\\n')[1],
               moduleAccessorsTest: eval('typeof fs') === 'undefined' ? null : eval('fs') === require('fs'),
               argv: [...process.argv]

--- a/src/test/repl/repl-environment.spec.ts
+++ b/src/test/repl/repl-environment.spec.ts
@@ -197,7 +197,7 @@ test.suite(
           exportsTest: true,
           // Note: vanilla node uses different name. See #1360
           stackTest: expect.stringContaining(
-            `    at ${join(TEST_DIR, '<repl>.ts')}:4:`
+            `    at ${join(TEST_DIR, '<repl>.cts')}:4:`
           ),
           moduleAccessorsTest: true,
           argv: [tsNodeExe],
@@ -350,7 +350,7 @@ test.suite(
           exportsTest: true,
           // Note: vanilla node uses different name. See #1360
           stackTest: expect.stringContaining(
-            `    at ${join(TEST_DIR, '<repl>.ts')}:4:`
+            `    at ${join(TEST_DIR, '<repl>.cts')}:4:`
           ),
           moduleAccessorsTest: true,
           argv: [tsNodeExe],
@@ -428,7 +428,7 @@ test.suite(
 
             // Note: vanilla node uses different name. See #1360
             stackTest: expect.stringContaining(
-              `    at ${join(TEST_DIR, '<repl>.ts')}:1:`
+              `    at ${join(TEST_DIR, '<repl>.cts')}:1:`
             ),
           },
         });
@@ -459,7 +459,7 @@ test.suite(
             exportsTest: true,
             // Note: vanilla node uses different name. See #1360
             stackTest: expect.stringContaining(
-              `    at ${join(TEST_DIR, '<repl>.ts')}:1:`
+              `    at ${join(TEST_DIR, '<repl>.cts')}:1:`
             ),
             moduleAccessorsTest: true,
           },

--- a/src/test/repl/repl.spec.ts
+++ b/src/test/repl/repl.spec.ts
@@ -1,5 +1,10 @@
 import { context, expect } from '../testlib';
-import { delay, resetNodeEnvironment, ts } from '../helpers';
+import {
+  CMD_TS_NODE_WITHOUT_PROJECT_FLAG,
+  delay,
+  resetNodeEnvironment,
+  ts,
+} from '../helpers';
 import semver = require('semver');
 import { CMD_TS_NODE_WITH_PROJECT_FLAG, ctxTsNode, TEST_DIR } from '../helpers';
 import { createExec, createExecTester } from '../exec-helpers';
@@ -10,6 +15,7 @@ import {
   macroReplStderrContains,
 } from './helpers';
 import { expectStream } from '@cspotcode/expect-stream';
+import { join } from 'path';
 
 const test = context(ctxTsNode).contextEach(ctxRepl);
 test.serial();
@@ -219,7 +225,7 @@ test.suite('top level await', ({ contextEach }) => {
 
       expect(r.stdout).toBe('> > ');
       expect(r.stderr.replace(/\r\n/g, '\n')).toBe(
-        '<repl>.ts(4,7): error TS2322: ' +
+        '<repl>.cts(4,7): error TS2322: ' +
           (semver.gte(ts.version, '4.0.0')
             ? `Type 'number' is not assignable to type 'string'.\n`
             : `Type '1' is not assignable to type 'string'.\n`) +
@@ -615,4 +621,18 @@ test.suite('REPL treats object literals and block scopes correctly', (test) => {
       "Property 'foo' does not exist on type"
     );
   });
+});
+
+test('repl executes input as cjs even in esm projects', async (t) => {
+  // Must exec child process, because we need a different cwd.
+  const p = exec(`${CMD_TS_NODE_WITHOUT_PROJECT_FLAG} -i`, {
+    cwd: join(TEST_DIR, 'repl-in-esm-package'),
+  });
+  p.child.stdin!.write(
+    'import fs2 from "fs"; fs2.existsSync("does not exist")'
+  );
+  p.child.stdin!.end();
+  const r = await p;
+  expect(r.stdout).toBe('> false\n> ');
+  expect(r.stderr).toBe('');
 });

--- a/src/test/repl/repl.spec.ts
+++ b/src/test/repl/repl.spec.ts
@@ -10,13 +10,14 @@ import semver = require('semver');
 import { CMD_TS_NODE_WITH_PROJECT_FLAG, ctxTsNode, TEST_DIR } from '../helpers';
 import { createExec, createExecTester } from '../exec-helpers';
 import { upstreamTopLevelAwaitTests } from './node-repl-tla';
-import {
-  ctxRepl,
-  macroReplNoErrorsAndStdoutContains,
-  macroReplStderrContains,
-} from './helpers';
+import { replFile } from './helpers/misc';
 import { expectStream } from '@cspotcode/expect-stream';
 import { join } from 'path';
+import { ctxRepl } from './helpers/ctx-repl';
+import {
+  macroReplNoErrorsAndStdoutContains,
+  macroReplStderrContains,
+} from './helpers/macros';
 
 const test = context(ctxTsNode).contextEach(ctxRepl);
 test.serial();
@@ -226,7 +227,7 @@ test.suite('top level await', ({ contextEach }) => {
 
       expect(r.stdout).toBe('> > ');
       expect(r.stderr.replace(/\r\n/g, '\n')).toBe(
-        '<repl>.cts(4,7): error TS2322: ' +
+        `${replFile}(4,7): error TS2322: ` +
           (semver.gte(ts.version, '4.0.0')
             ? `Type 'number' is not assignable to type 'string'.\n`
             : `Type '1' is not assignable to type 'string'.\n`) +

--- a/tests/repl-in-esm-package/package.json
+++ b/tests/repl-in-esm-package/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/tests/repl-in-esm-package/tsconfig.json
+++ b/tests/repl-in-esm-package/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "module": "nodenext"
+  }
+}


### PR DESCRIPTION
Changed the virtual filename `<repl>.ts` to `<repl>.cts`, but only on TS >= 4.5 which is the first version to support `cts` files.  Then added a test.

Fixes #1902
Fixes #1924