### PR TITLE
Remove create-require and yn dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
     "acorn": "^8.4.1",
     "acorn-walk": "^8.1.1",
     "arg": "^4.1.0",
-    "create-require": "^1.1.0",
     "diff": "^4.0.1",
     "make-error": "^1.1.1",
     "v8-compile-cache-lib": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -162,8 +162,7 @@
     "arg": "^4.1.0",
     "diff": "^4.0.1",
     "make-error": "^1.1.1",
-    "v8-compile-cache-lib": "^3.0.1",
-    "yn": "3.1.1"
+    "v8-compile-cache-lib": "^3.0.1"
   },
   "prettier": {
     "singleQuote": true

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,7 +4,7 @@ import { join, resolve, dirname, parse as parsePath, relative } from 'path';
 import { inspect } from 'util';
 import Module = require('module');
 let arg: typeof import('arg');
-import { parse, createRequire, hasOwnProperty, versionGteLt } from './util';
+import { parse, hasOwnProperty, versionGteLt } from './util';
 import {
   EVAL_FILENAME,
   EvalState,
@@ -739,7 +739,7 @@ function requireResolveNonCached(absoluteModuleSpecifier: string) {
   const { dir, base } = parsePath(absoluteModuleSpecifier);
   const relativeModuleSpecifier = `./${base}`;
 
-  const req = createRequire(
+  const req = Module.createRequire(
     join(dir, 'imaginaryUncacheableRequireResolveScript')
   );
   return req.resolve(relativeModuleSpecifier, {

--- a/src/test/helpers/misc.ts
+++ b/src/test/helpers/misc.ts
@@ -1,13 +1,11 @@
 /** types from ts-node under test */
 import type * as tsNodeTypes from '../../index';
-import type _createRequire from 'create-require';
 import { TEST_DIR } from './paths';
 import { join } from 'path';
 import { promisify } from 'util';
-const createRequire: typeof _createRequire = require('create-require');
+import { createRequire } from 'module';
 export { tsNodeTypes };
 
-// `createRequire` does not exist on older node versions
 export const testsDirRequire = createRequire(join(TEST_DIR, 'index.js'));
 
 export const ts = testsDirRequire('typescript') as typeof import('typescript');

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -14,7 +14,6 @@ import {
   tsSupportsStableNodeNextNode16,
 } from './helpers';
 import { lstatSync } from 'fs';
-import type _createRequire from 'create-require';
 import { createExec } from './exec-helpers';
 import {
   BIN_CWD_PATH,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,16 +1,5 @@
-import {
-  createRequire as nodeCreateRequire,
-  createRequireFromPath as nodeCreateRequireFromPath,
-} from 'module';
-import type _createRequire from 'create-require';
 import * as ynModule from 'yn';
 import { dirname } from 'path';
-
-/** @internal */
-export const createRequire =
-  nodeCreateRequire ??
-  nodeCreateRequireFromPath ??
-  (require('create-require') as typeof _createRequire);
 
 /**
  * Wrapper around yn module that returns `undefined` instead of `null`.

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,13 +1,22 @@
-import * as ynModule from 'yn';
 import { dirname } from 'path';
 
 /**
- * Wrapper around yn module that returns `undefined` instead of `null`.
- * This is implemented by yn v4, but we're staying on v3 to avoid v4's node 10 requirement.
  * @internal
+ * Copied from https://unpkg.com/yn@3.1.1/index.js
+ * Because people get weird when they see you have dependencies. /jk
+ * This is a lazy way to make the dep number go down, we haven't touched this
+ * dep in ages, and we didn't use all its features, so we stripped them.
  */
-export function yn(value: string | undefined) {
-  return ynModule(value) ?? undefined;
+export function yn(input: string | undefined) {
+  input = String(input).trim();
+
+  if (/^(?:y|yes|true|1)$/i.test(input)) {
+    return true;
+  }
+
+  if (/^(?:n|no|false|0)$/i.test(input)) {
+    return false;
+  }
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,13 +1515,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"create-require@npm:^1.1.0":
-  version: 1.1.1
-  resolution: "create-require@npm:1.1.1"
-  checksum: a9a1503d4390d8b59ad86f4607de7870b39cad43d929813599a23714831e81c520bddf61bcdd1f8e30f05fd3a2b71ae8538e946eb2786dc65c2bbc520f692eff
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -3832,7 +3825,6 @@ __metadata:
     arg: ^4.1.0
     ava: ^5.1.1
     axios: ^0.21.1
-    create-require: ^1.1.0
     diff: ^4.0.1
     dprint: ^0.25.0
     expect: 27.0.2

--- a/yarn.lock
+++ b/yarn.lock
@@ -3841,7 +3841,6 @@ __metadata:
     typescript: 4.7.4
     typescript-json-schema: ^0.54.0
     v8-compile-cache-lib: ^3.0.1
-    yn: 3.1.1
   peerDependencies:
     "@swc/core": ">=1.2.50"
     "@swc/wasm": ">=1.2.50"
@@ -4207,13 +4206,6 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^21.1.1
   checksum: 47da1b0d854fa16d45a3ded57b716b013b2179022352a5f7467409da5a04a1eef5b3b3d97a2dfc13e8bbe5f2ffc0afe3bc6a4a72f8254e60f5a4bd7947138643
-  languageName: node
-  linkType: hard
-
-"yn@npm:3.1.1":
-  version: 3.1.1
-  resolution: "yn@npm:3.1.1"
-  checksum: 2c487b0e149e746ef48cda9f8bad10fc83693cd69d7f9dcd8be4214e985de33a29c9e24f3c0d6bcf2288427040a8947406ab27f7af67ee9456e6b84854f02dd6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Create-require is not needed in node v14 and up.
yn is only a few lines and we are stuck on an old version anyway.