### PR TITLE
Update bundled `transpileModule` implementation to match latest TS codebase

### DIFF
--- a/src/test/helpers/version-checks.ts
+++ b/src/test/helpers/version-checks.ts
@@ -40,6 +40,8 @@ export const tsSupportsAllowImportingTsExtensions = semver.gte(
 );
 // TS 5.0 adds ability for tsconfig to `"extends": []` an array of configs
 export const tsSupportsExtendsArray = semver.gte(ts.version, '4.999.999');
+// TS 5.0 adds verbatimModuleSyntax
+export const tsSupportsVerbatimModuleSyntax = semver.gte(ts.version, '5.0.0');
 // Relevant when @tsconfig/bases refers to es2021 and we run tests against
 // old TS versions.
 export const tsSupportsEs2021 = semver.gte(ts.version, '4.3.0');

--- a/src/test/index.spec.ts
+++ b/src/test/index.spec.ts
@@ -305,28 +305,6 @@ test.suite('ts-node', (test) => {
       );
     });
 
-    test('should support transpile only mode', async () => {
-      const r = await exec(
-        `${CMD_TS_NODE_WITH_PROJECT_FLAG} --transpile-only -pe "x"`
-      );
-      if (r.err === null) {
-        throw new Error('Command was expected to fail, but it succeeded.');
-      }
-
-      expect(r.err.message).toMatch('ReferenceError: x is not defined');
-    });
-
-    test('should throw error even in transpileOnly mode', async () => {
-      const r = await exec(
-        `${CMD_TS_NODE_WITH_PROJECT_FLAG} --transpile-only -pe "console."`
-      );
-      if (r.err === null) {
-        throw new Error('Command was expected to fail, but it succeeded.');
-      }
-
-      expect(r.err.message).toMatch('error TS1003: Identifier expected');
-    });
-
     for (const flavor of [
       '--transpiler ts-node/transpilers/swc transpile-only-swc',
       '--transpiler ts-node/transpilers/swc-experimental transpile-only-swc',

--- a/src/test/transpile-only.spec.ts
+++ b/src/test/transpile-only.spec.ts
@@ -1,0 +1,51 @@
+import { createExec } from './exec-helpers';
+import { ctxTsNode, tsSupportsVerbatimModuleSyntax } from './helpers';
+import { CMD_TS_NODE_WITH_PROJECT_FLAG } from './helpers/command-lines';
+import { TEST_DIR } from './helpers/paths';
+import { expect, context } from './testlib';
+
+const test = context(ctxTsNode);
+
+const exec = createExec({
+  cwd: TEST_DIR,
+});
+
+test('should support transpile only mode', async () => {
+  const r = await exec(
+    `${CMD_TS_NODE_WITH_PROJECT_FLAG} --transpile-only -pe "x"`
+  );
+  if (r.err === null) {
+    throw new Error('Command was expected to fail, but it succeeded.');
+  }
+
+  expect(r.err.message).toMatch('ReferenceError: x is not defined');
+});
+
+test('should throw error even in transpileOnly mode', async () => {
+  const r = await exec(
+    `${CMD_TS_NODE_WITH_PROJECT_FLAG} --transpile-only -pe "console."`
+  );
+  if (r.err === null) {
+    throw new Error('Command was expected to fail, but it succeeded.');
+  }
+
+  expect(r.err.message).toMatch('error TS1003: Identifier expected');
+});
+
+test.suite(
+  'verbatimModuleSyntax w/transpileOnly should not raise configuration diagnostic',
+  (test) => {
+    test.if(tsSupportsVerbatimModuleSyntax);
+    test('test', async (t) => {
+      // Mixing verbatimModuleSyntax w/transpileOnly
+      // https://github.com/TypeStrong/ts-node/issues/1971
+      // We should *not* get:
+      // "error TS5104: Option 'isolatedModules' is redundant and cannot be specified with option 'verbatimModuleSyntax'."
+      const service = t.context.tsNodeUnderTest.create({
+        transpileOnly: true,
+        compilerOptions: { verbatimModuleSyntax: true },
+      });
+      service.compile('const foo: string = 123', 'module.ts');
+    });
+  }
+);


### PR DESCRIPTION
Fixes #1971 

### Implementation notes

We have a bundled copy of TS's `transpileModule` because we needed to make a couple tweaks that couldn't be done via public API.

Those differences are:

- Refactored into `createTsTranspileModule` which returns impl of `transpileModule`
  - ingest compiler options once, not on every single call to `transpileModule`
- `useCaseSensitiveFileNames` changed from `false` to `true`
- `fileExists` and `readFile` understand to return a `package.json` so that `module: NodeNext` emits correctly
  - local var `packageJsonFileName` added as part of this