### PR TITLE
Support `ts-node -p 123` equivalent to `-pe 123`

### DIFF
--- a/src/test/cli-args.spec.ts
+++ b/src/test/cli-args.spec.ts
@@ -1,0 +1,32 @@
+import { context } from './testlib';
+import { ctxTsNode, testsDirRequire } from './helpers';
+import type { ParsedArgv } from '../bin';
+const test = context(ctxTsNode);
+
+const argParseMacro = test.macro(
+  (args: string[], entrypointArgs: Record<string, any> | undefined, expectation: Partial<ParsedArgv>) => [
+    () => `"${args.join(' ')}"${entrypointArgs ? ` w/entrypoint args: ${JSON.stringify(entrypointArgs)}` : ``}`,
+    async (t) => {
+      const parsedArgs = t.context.tsNodeBin.parseArgv(args, entrypointArgs ?? {});
+      t.like(parsedArgs, expectation);
+    },
+  ]
+);
+
+test(argParseMacro, ['-pe', '123'], undefined, {
+  print: true,
+  code: '123',
+  restArgs: [],
+});
+
+test(argParseMacro, ['-p', '123'], undefined, {
+  print: true,
+  code: '123',
+  restArgs: [],
+});
+
+test(argParseMacro, ['-e', '123'], undefined, {
+  print: false,
+  code: '123',
+  restArgs: [],
+});

--- a/src/test/helpers/ctx-ts-node.ts
+++ b/src/test/helpers/ctx-ts-node.ts
@@ -6,14 +6,16 @@ import { join } from 'path';
 import type { ExecutionContext } from '../testlib';
 import { sync as rimrafSync } from 'rimraf';
 import { TEST_DIR } from './paths';
-import { testsDirRequire, tsNodeTypes } from './misc';
+import { testsDirRequire, tsNodeBinTypes, tsNodeTypes } from './misc';
 
 /** Pass to `test.context()` to get access to the ts-node API under test */
 export async function ctxTsNode() {
   await installTsNode();
   const tsNodeUnderTest: typeof tsNodeTypes = testsDirRequire('ts-node');
+  const tsNodeBin: typeof tsNodeBinTypes = testsDirRequire('ts-node/dist/bin');
   return {
     tsNodeUnderTest,
+    tsNodeBin,
   };
 }
 export namespace ctxTsNode {

--- a/src/test/helpers/misc.ts
+++ b/src/test/helpers/misc.ts
@@ -1,10 +1,11 @@
 /** types from ts-node under test */
 import type * as tsNodeTypes from '../../index';
+import type * as tsNodeBinTypes from '../../bin';
 import { TEST_DIR } from './paths';
 import { join } from 'path';
 import { promisify } from 'util';
 import { createRequire } from 'module';
-export { tsNodeTypes };
+export { tsNodeTypes, tsNodeBinTypes };
 
 export const testsDirRequire = createRequire(join(TEST_DIR, 'index.js'));
 

--- a/src/test/repl/repl.spec.ts
+++ b/src/test/repl/repl.spec.ts
@@ -222,8 +222,8 @@ test.suite('top level await', ({ contextEach }) => {
   });
 
   test('should pass upstream test cases', async (t) => {
-    const { tsNodeUnderTest } = t.context;
-    await upstreamTopLevelAwaitTests({ TEST_DIR, tsNodeUnderTest });
+    const { tsNodeUnderTest, tsNodeBin } = t.context;
+    await upstreamTopLevelAwaitTests({ TEST_DIR, tsNodeUnderTest, tsNodeBin });
   });
 });
 


### PR DESCRIPTION
Pending https://discord.com/channels/508357248330760243/933130253692436560/1105333478138060862

Even if I don't keep this behavior, should at least merge the improved test-ability.

Related to bullet point on https://github.com/TypeStrong/ts-node/issues/1505