### PR TITLE
Always treat experimentalDecorators as a boolean

### DIFF
--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -217,7 +217,7 @@ export function createSwcOptions(
         parser: {
           syntax: 'typescript',
           tsx: isTsx,
-          decorators: experimentalDecorators,
+          decorators: !!experimentalDecorators,
           dynamicImport: true,
           importAssertions: true,
         } as swcWasm.TsParserConfig,


### PR DESCRIPTION
Fix a nasty bug that you can run into if you haven't defined experimentalDecorators in your tsconfig.json.

At the moment the `decorators` property will be passed as to SWC as `undefined`, which causes a validation failure as it regards this as type `unit` but it expects `boolean`.

Unfortunately as the error is bubbled up from SWC it ends up with a rust-flavoured stack trace which is hard to debug. I only found this by trial-and-error commenting out properties until I found the one that was causing the issue.

The fix is simple. Force experimentalDecorators to be evaluated as a boolean by prefixing it with !!