### PR TITLE
Pass useDefineForClassFields tsconfig compiler option to SWC

### DIFF
--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -134,6 +134,7 @@ export function createSwcOptions(
     importHelpers,
     experimentalDecorators,
     emitDecoratorMetadata,
+    useDefineForClassFields,
     target,
     module,
     jsx,
@@ -225,6 +226,7 @@ export function createSwcOptions(
         transform: {
           decoratorMetadata: emitDecoratorMetadata,
           legacyDecorator: true,
+          useDefineForClassFields,
           react: {
             throwIfNamespace: false,
             development: jsxDevelopment,


### PR DESCRIPTION
Defaults for this option may be different between tsc and SWC, and explicit override in ts-node is ignored.

This prevents drop-in replacement of `ts-node --swc` in place of `ts-node` for cases when the value of `useDefineForClassFields` is important

Here is an example of the problem this PR is attempting to fix:

tsconfig.json:
```json
{
  "compilerOptions": {
    "target": "es2021",
    "useDefineForClassFields": false
  }
}
```

```bash
$ ts-node -pe 'new class { f?:any }'
{}

$ ts-node --swc -pe 'new class { f?:any }'
{ f: undefined } # but should be {}
```