### PR TITLE
remove swc experimental options

### DIFF
--- a/src/test/transpilers.spec.ts
+++ b/src/test/transpilers.spec.ts
@@ -120,23 +120,4 @@ test.suite('swc', (test) => {
       );
     });
   });
-
-  test.suite('preserves import assertions for json imports', (test) => {
-    test.if(tsSupportsImportAssertions);
-    test(
-      'basic json import',
-      compileMacro,
-      { module: 'esnext' },
-      outdent`
-        import document from './document.json' assert {type: 'json'};
-        document;
-      `,
-      outdent`
-        import document from './document.json' assert {
-            type: 'json'
-        };
-        document;
-      `
-    );
-  });
 });

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -235,9 +235,6 @@ export function createSwcOptions(
           },
         },
         keepClassNames,
-        experimental: {
-          keepImportAssertions: true,
-        },
       },
     };
 


### PR DESCRIPTION
This removes support for keeping import assertions, which were broken in swc at some point, and unconditionally transpiled into import attributes. (Ie, `import/with` instead of `import/assert`.)

No version of node supports import attributes with this syntax yet, so anyone using swc to import json in ESM is out of luck no matter what.

And swc 1.3.83 broke the option that ts-node was using. The position of the swc project is that experimental features are not supported, and may change in patch versions without warning, making them unsafe to rely on (as evidenced here, and the reason why this behavior changed unexpectedly in the first place).

Better to just not use experimental swc features, and let it remove import assertions rather than transpile them into something that node can't run.

Fix: https://github.com/TypeStrong/ts-node/issues/2056