### PR TITLE
fix: bug with latest version of @swc/wasm (#2059)

### DIFF
--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -225,7 +225,7 @@ export function createSwcOptions(
         parser: {
           syntax: 'typescript',
           tsx: isTsx,
-          decorators: experimentalDecorators,
+          decorators: !!experimentalDecorators,
           dynamicImport: true,
           importAssertions: true,
         } as swcWasm.TsParserConfig,


### PR DESCRIPTION
fix: bug with latest version of @swc/wasm causing "error when attempting to validate swc compiler options"; fixes https://github.com/TypeStrong/ts-node/issues/2059