### PR TITLE
feat(esm): initialize hook - register(_,[_,tsNodeOptions])

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -4,4 +4,30 @@ const require = createRequire(fileURLToPath(import.meta.url));
 
 /** @type {import('./dist/esm')} */
 const esm = require('./dist/esm');
-export const { resolve, load, getFormat, transformSource } = esm.registerAndCreateEsmHooks();
+
+/** @type {ReturnType<typeof esm['registerAndCreateEsmHooks']> | undefined} */
+let loader = undefined;
+
+export function resolve(...args) {
+  if (!loader) initialize();
+  return loader.resolve.apply(this, args);
+}
+
+export function load(...args) {
+  if (!loader) initialize();
+  return loader.load.apply(this, args);
+}
+
+export function getFormat(...args) {
+  if (!loader) initialize();
+  return loader.getFormat.apply(this, args);
+}
+
+export function transformSource(...args) {
+  if (!loader) initialize();
+  return loader.transformSource.apply(this, args);
+}
+
+export function initialize(tsNodeOptions) {
+  loader = esm.registerAndCreateEsmHooks(tsNodeOptions);
+}


### PR DESCRIPTION
Opening for feedback!

It would be nice to pass ts-node options via the node `register` call.

Enabling an entry point like the following:

```javascript
import { register } from 'node:module'

register(import.meta.resolve('ts-node/esm'), {
  data: {
    swc: true,
    preferTsExts: true,
  },
})

await import('./main.js')
```