### PR TITLE
Fix SWC support with stage 3 decorators

### DIFF
--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "@swc/core": ">=1.3.85",
     "@swc/wasm": ">=1.3.85",
     "@types/node": "*",
-    "typescript": ">=4.4"
+    "typescript": ">=5.0"
   },
   "peerDependenciesMeta": {
     "@swc/core": {

--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -225,14 +225,15 @@ export function createSwcOptions(
         parser: {
           syntax: 'typescript',
           tsx: isTsx,
-          decorators: experimentalDecorators,
+          decorators: true,
           dynamicImport: true,
           importAssertions: true,
         } as swcWasm.TsParserConfig,
         target: swcTarget as swcWasm.JscTarget,
         transform: {
           decoratorMetadata: emitDecoratorMetadata,
-          legacyDecorator: true,
+          legacyDecorator: experimentalDecorators,
+          decoratorVersion: experimentalDecorators ? '2021-12' : '2022-03',
           react: {
             throwIfNamespace: false,
             development: jsxDevelopment,


### PR DESCRIPTION
Since TypeScript 5.0, stage 3 decorators had become the default while `experimentalDecorators` had become the legacy standard. However, with SWC enabled, ts-node doesn't work correctly with stage 3 decorators. This PR fixes the config pass to SWC to make it things work as it should.

Note: This part of the SWC config has been there since v1.3.47, so there's no need the change the dependency specifications.