### PR TITLE
fix(internals): enable tsc noderesolution features

### DIFF
--- a/src/ts-internals.ts
+++ b/src/ts-internals.ts
@@ -48,7 +48,7 @@ function createTsInternalsUncached(_ts: TSCommon) {
       host,
       /*cache*/ undefined,
       /*projectRefs*/ undefined,
-      /*conditionsOrIsConfigLookup*/ tsGte5_3_0 ? undefined : true,
+      /*conditionsOrIsConfigLookup*/ tsGte5_3_0 ? [] : true,
       /*isConfigLookup*/ tsGte5_3_0 ? true : undefined
     );
     if (resolved.resolvedModule) {


### PR DESCRIPTION
- closes https://github.com/TypeStrong/ts-node/issues/2146.

As noted in issue, settings conditions to `undefined` force disables all of node resolution features including import / export subpath map. (https://github.com/microsoft/TypeScript/blob/v5.7.2/src/compiler/moduleNameResolver.ts#L1787)

PR sets an empty array instead to allow to enable those resolution features.