### PR TITLE
Unify tsc and swc behaviour for `experimentalDecorators`

### DIFF
--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -225,14 +225,15 @@ export function createSwcOptions(
         parser: {
           syntax: 'typescript',
           tsx: isTsx,
-          decorators: experimentalDecorators,
+          decorators: true,
           dynamicImport: true,
           importAssertions: true,
         } as swcWasm.TsParserConfig,
         target: swcTarget as swcWasm.JscTarget,
         transform: {
           decoratorMetadata: emitDecoratorMetadata,
-          legacyDecorator: true,
+          legacyDecorator: experimentalDecorators,
+          decoratorVersion: experimentalDecorators ? undefined : '2022-03',
           react: {
             throwIfNamespace: false,
             development: jsxDevelopment,


### PR DESCRIPTION
`tsconfig.experimentalDecorators` controls how tsc transpile the decorators

|      tsconfig.experimentalDecorators      | false  | true   |
|--------------------------------|--------------------------------|--------------------------------|
| tsc behaviour                  | transpile stage 3 decorators   | transpile legacy decorators    |
| swc behaviour pre-this-pr       | no decorators transpiling at all | transpile legacy decorators    |
| swc behaviour post-this-pr    | transpile stage 3 decorators   | transpile legacy decorators    |
