### PR TITLE
chore: add es2023 and es2024 as swc supported targets

### DIFF
--- a/src/transpilers/swc.ts
+++ b/src/transpilers/swc.ts
@@ -80,6 +80,8 @@ targetMapping.set(/* ts.ScriptTarget.ES2019 */ 6, 'es2019');
 targetMapping.set(/* ts.ScriptTarget.ES2020 */ 7, 'es2020');
 targetMapping.set(/* ts.ScriptTarget.ES2021 */ 8, 'es2021');
 targetMapping.set(/* ts.ScriptTarget.ES2022 */ 9, 'es2022');
+targetMapping.set(/* ts.ScriptTarget.ES2023 */ 10, 'es2023');
+targetMapping.set(/* ts.ScriptTarget.ES2024 */ 11, 'es2024');
 targetMapping.set(/* ts.ScriptTarget.ESNext */ 99, 'esnext');
 
 type SwcTarget = typeof swcTargets[number];
@@ -98,6 +100,8 @@ const swcTargets = [
   'es2020',
   'es2021',
   'es2022',
+  'es2023',
+  'es2024',
   'esnext',
 ] as const;
 


### PR DESCRIPTION
Resolves https://github.com/TypeStrong/ts-node/issues/2160

This PR adds ES2023 and ES2024 as SWC supported targets. 
SWC since https://github.com/swc-project/swc/pull/9700 (2024-11-04) supports ES2023 and ES2024
